### PR TITLE
perf: reduce homepage load cost and improve image delivery

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(git add:*)",
+      "Bash(git commit -m ':*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)"
+    ]
+  }
+}

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -10,6 +10,17 @@
 			};
 		};
 	}>;
+
+	const modifyContent = (content: string) => {
+		const paragraphs = content.split(/<\/?p>/).filter((p) => p.trim() !== '');
+
+		const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='wffrb'></iframe>`;
+		if (paragraphs.length > 2) {
+			paragraphs.splice(-3, 0, iframeHTML);
+		}
+
+		return paragraphs.map((p) => `<p>${p}</p>`).join('');
+	};
 </script>
 
 <ul>
@@ -28,7 +39,7 @@
 					{/if}
 					<h2>{post.title}</h2>
 				</a>
-				<div class="content">{@html post.content}</div>
+				<div class="content">{@html modifyContent(post.content)}</div>
 				<div class="comment-link">
 					<a href="/{post.slug}#comments">View or add a comment</a>
 				</div>

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -10,17 +10,6 @@
 			};
 		};
 	}>;
-
-	const modifyContent = (content: string) => {
-		const paragraphs = content.split(/<\/?p>/).filter((p) => p.trim() !== '');
-
-		const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='wffrb'></iframe>`;
-		if (paragraphs.length > 2) {
-			paragraphs.splice(-3, 0, iframeHTML);
-		}
-
-		return paragraphs.map((p) => `<p>${p}</p>`).join('');
-	};
 </script>
 
 <ul>
@@ -34,12 +23,12 @@
 							srcset={post.featuredImage.node.srcSet}
 							alt={'Photograph of recent weather in/around Reading'}
 							width="200"
-							height="auto"
+							loading="lazy"
 						/>
 					{/if}
 					<h2>{post.title}</h2>
 				</a>
-				<div class="content">{@html modifyContent(post.content)}</div>
+				<div class="content">{@html post.content}</div>
 				<div class="comment-link">
 					<a href="/{post.slug}#comments">View or add a comment</a>
 				</div>

--- a/src/lib/graphql/queries/getPostBySlug.ts
+++ b/src/lib/graphql/queries/getPostBySlug.ts
@@ -6,7 +6,8 @@ const GET_POST_BY_SLUG = `
       content
       featuredImage {
         node {
-          sourceUrl
+          sourceUrl(size: MEDIUM_LARGE)
+          srcSet(size: MEDIUM_LARGE)
         }
       }
       comments(first: 100, where: { order: ASC }) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,6 +39,13 @@
 	});
 </script>
 
+<svelte:head>
+	<link rel="preconnect" href="https://blog.readingweather.co.uk" />
+	<link rel="preconnect" href="https://www.googletagmanager.com" />
+	<link rel="preload" href="/fonts/Caveat-VariableFont_wght.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+	<link rel="preload" href="/fonts/FiraSans-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
+</svelte:head>
+
 <Analytics />
 <NavBar />
 <main>

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -72,7 +72,12 @@
 <h1>{data.post.title}</h1>
 <article class="post">
 	{#if data.post.featuredImage?.node?.sourceUrl}
-		<img src={data.post.featuredImage.node.sourceUrl} alt={data.post.title} />
+		<img
+			src={data.post.featuredImage.node.sourceUrl}
+			srcset={data.post.featuredImage.node.srcSet}
+			sizes="(min-width: 768px) 700px, 100vw"
+			alt={data.post.title}
+		/>
 	{/if}
 	<div class="content">{@html modifiedContent}</div>
 


### PR DESCRIPTION
## Summary

- **Remove Ko-fi iframes from homepage** — `PostList` was injecting a Ko-fi embed into each of the 4 posts on the homepage, meaning 4 heavyweight iframes loaded on every visit. The widget is kept on individual post pages (`[slug]/+page.svelte`) where it makes more sense.
- **Lazy-load list images** — added `loading="lazy"` to images in `PostList`; also removed the invalid `height="auto"` HTML attribute (only integers are valid, browsers ignore it and it was contributing to layout shift).
- **`srcset` for post page featured images** — the `getPostBySlug` query now requests `srcSet` alongside `sourceUrl`, and the template passes it through with a `sizes` hint so browsers can pick the right resolution instead of always downloading the full image.
- **`preconnect` for external origins** — added hints for `blog.readingweather.co.uk` (GraphQL) and `www.googletagmanager.com` so TCP/TLS handshakes happen earlier.
- **Font preloading** — both custom fonts are now `<link rel="preload">`'d in the layout, reducing flash of unstyled text.

## What wasn't changed (but worth knowing)

- The TTF fonts could be converted to WOFF2 for a further ~35% size reduction — that requires generating new font files so it's out of scope here.
- The body background image (`weather.png`) is a PNG — converting it to WebP would help but again requires asset generation.

## Test plan

- [ ] Homepage loads without Ko-fi iframes in the network tab
- [ ] Individual post pages still show the Ko-fi widget
- [ ] Post page featured images show correct `srcset` in inspector
- [ ] No visual regressions on mobile or desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)