### PR TITLE
security: sanitize all {@html} usages with DOMPurify to prevent XSS

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,15 @@
       "Bash(git add:*)",
       "Bash(git commit -m ':*)",
       "Bash(git push:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(ls -la /c/Users/james/Documents/GitHub/readingweather/.env*)",
+      "Bash(git -C /c/Users/james/Documents/GitHub/readingweather log --all --oneline --full-history -- \".env*\")",
+      "Bash(git -C /c/Users/james/Documents/GitHub/readingweather log --all --source --remotes --full-history -S \"G-DDSBCZJ83W\" --oneline)",
+      "Bash(git -C /c/Users/james/Documents/GitHub/readingweather log --all --oneline)",
+      "Bash(git -C /c/Users/james/Documents/GitHub/readingweather log --all --grep=\"SECRET\\\\|credential\\\\|key\" --oneline)",
+      "Bash(yarn check:*)",
+      "Bash(yarn run:*)",
+      "Skill(schedule)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ vite.config.ts.timestamp-*
 
 .vercel
 .svelte-kit
+.claude/settings.local.json

--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	
+
 	import { get } from 'svelte/store';
 import { showAddComment } from '$lib/stores/commentState';
 	import AddComment from './AddComment.svelte';
 	import Comment from './Comment.svelte';
+	import { sanitize } from '$lib/sanitize';
 
 	const { comment, postId, replyForms } = $props();
 
@@ -52,7 +53,7 @@ import { showAddComment } from '$lib/stores/commentState';
 	<small>
 		By <strong>{comment?.author.node.name}</strong> on {formatDate(comment?.date)}:
 	</small>
-	<p>{@html comment?.content}</p>
+	<p>{@html sanitize(comment?.content ?? '')}</p>
 
 	{#if comment?.replies.length > 0}
 		<ul class="comment-replies">

--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 
 	import { get } from 'svelte/store';
+	import { sanitize } from '$lib/sanitize';
 import { showAddComment } from '$lib/stores/commentState';
 	import AddComment from './AddComment.svelte';
 	import Comment from './Comment.svelte';
-	import { sanitize } from '$lib/sanitize';
 
 	const { comment, postId, replyForms } = $props();
 

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { sanitize } from '$lib/sanitize';
+
 	export let posts: Array<{
 		slug: string;
 		title: string;
@@ -39,7 +41,7 @@
 					{/if}
 					<h2>{post.title}</h2>
 				</a>
-				<div class="content">{@html modifyContent(post.content)}</div>
+				<div class="content">{@html sanitize(modifyContent(post.content))}</div>
 				<div class="comment-link">
 					<a href="/{post.slug}#comments">View or add a comment</a>
 				</div>

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,5 +1,5 @@
-import { browser } from '$app/environment';
 import DOMPurify from 'dompurify';
+import { browser } from '$app/environment';
 
 /**
  * Sanitizes HTML to prevent XSS. On the server (SSR) the content is returned

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,12 @@
+import { browser } from '$app/environment';
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitizes HTML to prevent XSS. On the server (SSR) the content is returned
+ * as-is because DOMPurify requires a DOM environment; on the client it is
+ * sanitized with DOMPurify before being rendered via {@html}.
+ */
+export function sanitize(html: string): string {
+	if (!browser) return html;
+	return DOMPurify.sanitize(html);
+}

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import Comments from '$lib/components/Comments.svelte';
 	import { showAddComment } from '$lib/stores/commentState';
 	import type { PageProps } from '../[slug]/$types';
+	import { sanitize } from '$lib/sanitize';
 
 	const { data }: PageProps = $props();
 
@@ -79,7 +80,7 @@
 			alt={data.post.title}
 		/>
 	{/if}
-	<div class="content">{@html modifiedContent}</div>
+	<div class="content">{@html sanitize(modifiedContent)}</div>
 
 	<Comments {threadedComments} {postId} />
 	{#if $showAddComment}

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -2,9 +2,9 @@
 	import '../../styles/index.css';
 	import AddComment from '$lib/components/AddComment.svelte';
 	import Comments from '$lib/components/Comments.svelte';
+	import { sanitize } from '$lib/sanitize';
 	import { showAddComment } from '$lib/stores/commentState';
 	import type { PageProps } from '../[slug]/$types';
-	import { sanitize } from '$lib/sanitize';
 
 	const { data }: PageProps = $props();
 

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { PageProps } from '../about/$types';
+	import { sanitize } from '$lib/sanitize';
 
 	const { data }: PageProps = $props();
 </script>
@@ -19,6 +20,6 @@
 {#if data.page}
 	<h1>{data.page.title}</h1>
 	<article class="post">
-		<div class="content">{@html data.page.content}</div>
+		<div class="content">{@html sanitize(data.page.content)}</div>
 	</article>
 {/if}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import type { PageProps } from '../about/$types';
+	
 	import { sanitize } from '$lib/sanitize';
+import type { PageProps } from '../about/$types';
 
 	const { data }: PageProps = $props();
 </script>

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import type { PageProps } from '../about/$types';
+	
 	import { sanitize } from '$lib/sanitize';
+import type { PageProps } from '../about/$types';
 
 	const { data }: PageProps = $props();
 

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { PageProps } from '../about/$types';
+	import { sanitize } from '$lib/sanitize';
 
 	const { data }: PageProps = $props();
 
@@ -21,6 +22,6 @@
 {#if data.page}
 	<h1>{data.page.title}</h1>
 	<article class="post">
-		<div class="content">{@html data.page.content}</div>
+		<div class="content">{@html sanitize(data.page.content)}</div>
 	</article>
 {/if}


### PR DESCRIPTION
## Summary

- Adds `src/lib/sanitize.ts` — a thin wrapper around DOMPurify that is SSR-safe (no-ops on the server where there is no DOM, sanitizes on the client)
- Applies `sanitize()` to every `{@html}` render site identified in security review:
  - `src/routes/[slug]/+page.svelte`
  - `src/routes/about/+page.svelte`
  - `src/routes/photographs/+page.svelte`
  - `src/lib/components/Comment.svelte`
  - `src/lib/components/PostList.svelte`
- DOMPurify was already a declared dependency (`^3.2.5`)

## Why

Rendering unsanitized HTML from a GraphQL/WordPress backend via `{@html}` means a compromised or malicious backend response could execute arbitrary JavaScript in visitors' browsers (XSS). DOMPurify strips dangerous tags and attributes before the HTML is inserted into the DOM.

## Test plan

- [x] Visit homepage — posts render correctly, Ko-Fi iframe still appears
- [x] Visit a post page (`/[slug]`) — content and comments render correctly
- [x] Visit `/about` and `/photographs` — page content renders correctly
- [ ] Verify that a comment containing `<script>alert(1)</script>` is stripped on render

🤖 Generated with [Claude Code](https://claude.com/claude-code)