### PR TITLE
security: add HTTP security headers via SvelteKit server hook

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,61 @@
+import type { Handle } from '@sveltejs/kit';
+
+const securityHeaders = {
+	// Prevent this site from being embedded in iframes on other origins (clickjacking)
+	'X-Frame-Options': 'SAMEORIGIN',
+
+	// Stop browsers from MIME-sniffing the content type
+	'X-Content-Type-Options': 'nosniff',
+
+	// Only send origin (no path) in the Referer header for cross-origin requests
+	'Referrer-Policy': 'strict-origin-when-cross-origin',
+
+	// Restrict access to powerful browser APIs
+	'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=()',
+
+	// Content Security Policy
+	// Notes on unsafe-inline for scripts: the Google Tag Manager snippet injected via
+	// <svelte:head> in analytics.svelte is an inline script. Removing unsafe-inline
+	// would require threading a nonce through to that script — a future improvement.
+	'Content-Security-Policy': [
+		"default-src 'self'",
+
+		// Scripts: own origin + Google Analytics/GTM + AdSense
+		// unsafe-inline is required by the GTM initialisation snippet
+		"script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://www.google-analytics.com https://googleads.g.doubleclick.net",
+
+		// Styles: own origin; unsafe-inline needed for Svelte's scoped styles
+		"style-src 'self' 'unsafe-inline'",
+
+		// Images: own origin, data URIs (inline images), WordPress media, ad networks
+		"img-src 'self' data: https://blog.readingweather.co.uk https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://www.google.com https://www.gstatic.com",
+
+		// Fonts: own origin only (fonts are self-hosted)
+		"font-src 'self'",
+
+		// Frames: Ko-Fi donation widget + AdSense ad iframes
+		"frame-src https://ko-fi.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com",
+
+		// Fetch/XHR: own origin + WordPress GraphQL backend + Analytics beacons
+		"connect-src 'self' https://blog.readingweather.co.uk https://www.google-analytics.com https://stats.g.doubleclick.net https://region1.google-analytics.com",
+
+		// Disallow <object>, <embed>, <applet>
+		"object-src 'none'",
+
+		// Restrict <base> tag to same origin
+		"base-uri 'self'",
+
+		// Limit where forms can be submitted
+		"form-action 'self' https://blog.readingweather.co.uk"
+	].join('; ')
+};
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const response = await resolve(event);
+
+	for (const [header, value] of Object.entries(securityHeaders)) {
+		response.headers.set(header, value);
+	}
+
+	return response;
+};


### PR DESCRIPTION
## Summary

- Creates `src/hooks.server.ts` — SvelteKit's server hook, which runs on every request and is the standard place to set response headers
- Adds the following headers to all responses:

| Header | Value | Purpose |
|--------|-------|---------|
| `Content-Security-Policy` | See below | Restricts what resources the browser may load |
| `X-Frame-Options` | `SAMEORIGIN` | Clickjacking protection (older browsers) |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits referrer leakage on cross-origin navigations |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` | Disables unused powerful browser APIs |

### CSP breakdown

The CSP is tuned to the external resources the app actually uses:
- **Google Analytics / GTM** — `script-src`, `connect-src`, `img-src`
- **Google AdSense** — `script-src`, `frame-src`, `img-src`
- **Ko-Fi widget** — `frame-src`
- **WordPress GraphQL backend** (`blog.readingweather.co.uk`) — `connect-src`, `img-src`
- **Self-hosted fonts** — `font-src 'self'`

> **Note on `unsafe-inline`:** The GTM initialisation snippet in `analytics.svelte` is an inline `<script>`. Until that is refactored to use a nonce (threaded through SvelteKit's hooks), `unsafe-inline` is required in `script-src`. This is documented in a comment in the hook file.

## Test plan

- [ ] Load the homepage — posts, images, fonts, and Ko-Fi widget all render
- [ ] Check browser DevTools → Network → response headers include the new headers
- [ ] Verify Google Analytics events still fire (no CSP blocks in the console)
- [ ] Verify AdSense ads still load
- [ ] Visit `/about` and a post page — no console CSP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)