### PR TITLE
perf: add image dimensions to prevent CLS and fix layout event syntax

### DIFF
--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -7,6 +7,9 @@
 			node?: {
 				sourceUrl: string;
 				srcSet: string;
+				mediaDetails?: {
+					height?: number;
+				};
 			};
 		};
 	}>;
@@ -34,6 +37,7 @@
 							srcset={post.featuredImage.node.srcSet}
 							alt={'Photograph of recent weather in/around Reading'}
 							width="200"
+							height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 							loading="lazy"
 						/>
 					{/if}

--- a/src/lib/graphql/queries/allPosts.ts
+++ b/src/lib/graphql/queries/allPosts.ts
@@ -9,6 +9,9 @@ const ALL_POSTS_QUERY = `
           node {
             sourceUrl(size: MEDIUM_LARGE)
             srcSet(size: MEDIUM_LARGE)
+            mediaDetails {
+              height
+            }
           }
         }
         content

--- a/src/lib/graphql/queries/getPostBySlug.ts
+++ b/src/lib/graphql/queries/getPostBySlug.ts
@@ -8,6 +8,10 @@ const GET_POST_BY_SLUG = `
         node {
           sourceUrl(size: MEDIUM_LARGE)
           srcSet(size: MEDIUM_LARGE)
+          mediaDetails {
+            width
+            height
+          }
         }
       }
       comments(first: 100, where: { order: ASC }) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -58,7 +58,7 @@
 			Please note that this feature is experimental - if you sign up you may also receive multiple
 			test messages until I'm satisfied it is working!
 		</p>
-		<form id="subscribe-form" on:submit={handleSubmit}>
+		<form id="subscribe-form" onsubmit={handleSubmit}>
 			<label>
 				Name:
 				<input autocomplete="name" type="text" bind:value={name} required />

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -77,6 +77,8 @@
 			srcset={data.post.featuredImage.node.srcSet}
 			sizes="(min-width: 768px) 700px, 100vw"
 			alt={data.post.title}
+			width={data.post.featuredImage.node.mediaDetails?.width ?? undefined}
+			height={data.post.featuredImage.node.mediaDetails?.height ?? undefined}
 		/>
 	{/if}
 	<div class="content">{@html modifiedContent}</div>


### PR DESCRIPTION
## Summary

Wednesday performance & SvelteKit optimisation audit — 2026-04-15.

### Changes

- **Prevent Cumulative Layout Shift (CLS) on post pages** — the featured image in `[slug]/+page.svelte` had no `width` or `height` attributes, so the browser had no way to pre-allocate space before the image loaded. Added `mediaDetails { width height }` to the `GetPostBySlug` GraphQL query and passed the returned values as HTML attributes on the `<img>`. Modern browsers use these as an intrinsic aspect-ratio hint even when CSS overrides the rendered size, which eliminates the layout jump.

- **Same fix for the home-page post list** — `allPosts.ts` already requested `MEDIUM_LARGE` images (fixed width), but `PostList.svelte` only had a hard-coded `width="200"` with no `height`. Added `mediaDetails { height }` to the query, updated the `PostList` prop type to expose it, and passed it as the `height` attribute so the browser can calculate the correct aspect ratio.

- **Fix `on:submit` → `onsubmit` in `+layout.svelte`** — the layout uses Svelte 5 runes (`$state`, `$props`) so it is compiled in runes mode, where the legacy `on:event` directive syntax is invalid. The subscribe form was using `on:submit={handleSubmit}`, which Svelte 5 silently ignores (or warns about) in runes mode, meaning the form handler may not attach correctly after hydration. Changed to the correct `onsubmit={handleSubmit}`.

### Why these changes matter

| Issue | Metric impacted |
|---|---|
| Missing image dimensions | CLS (Core Web Vitals) |
| Missing image dimensions | LCP (browser can start painting sooner) |
| `on:submit` in runes mode | Correctness / hydration reliability |

### Files changed

| File | Change |
|---|---|
| `src/lib/graphql/queries/getPostBySlug.ts` | Add `mediaDetails { width height }` |
| `src/lib/graphql/queries/allPosts.ts` | Add `mediaDetails { height }` |
| `src/routes/[slug]/+page.svelte` | Pass `width`/`height` to featured image |
| `src/lib/components/PostList.svelte` | Pass `height` to list images; extend prop type |
| `src/routes/+layout.svelte` | `on:submit` → `onsubmit` |

## Test plan

- [x] Visit a post page — confirm featured image loads without the page jumping (no CLS)
- [x] Visit the home page — confirm post-list images load without height flicker
- [x] Submit the newsletter subscribe form in the footer — confirm it still posts correctly (tests the `onsubmit` fix)
- [x] Run `yarn build` with no type errors

https://claude.ai/code/session_016e2bBz4u83phcq1bzDyrv5