### PR TITLE
fix(a11y): address minor accessibility issues

### DIFF
--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -51,15 +51,15 @@
 	{#if !successMessage}
 		<div>
 			<label for="name">Name:</label>
-			<input type="text" bind:value={name} id="name" name="name" required />
+			<input type="text" bind:value={name} id="name" name="name" required aria-required="true" />
 		</div>
 		<div>
 			<label for="email">Email:</label>
-			<input type="email" bind:value={email} id="email" name="email" required />
+			<input type="email" bind:value={email} id="email" name="email" required aria-required="true" />
 		</div>
 		<div>
 			<label for="comment">Comment:</label>
-			<textarea bind:value={commentContent} id="comment" name="comment" required></textarea>
+			<textarea bind:value={commentContent} id="comment" name="comment" required aria-required="true"></textarea>
 		</div>
 		<button type="submit" disabled={submitting}>
 			{submitting ? 'Submitting...' : 'Post Comment'}

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -22,7 +22,11 @@
 		aria-expanded={isOpen}
 		aria-controls="nav-menu"
 	>
-		☰
+		<svg aria-hidden="true" focusable="false" width="24" height="24" viewBox="0 0 24 24">
+			<rect y="4" width="24" height="2" fill="currentColor" />
+			<rect y="11" width="24" height="2" fill="currentColor" />
+			<rect y="18" width="24" height="2" fill="currentColor" />
+		</svg>
 	</button>
 
 	<ul

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -39,8 +39,8 @@
 				<a
 					href={link.href}
 					on:click={() => (isOpen = false)}
-					aria-current={$page.url.pathname === link.href ? 'page' : undefined}
-				>{link.label}</a>
+					aria-current={$page.url.pathname === link.href ? 'page' : undefined}>{link.label}</a
+				>
 			</li>
 		{/each}
 	</ul>
@@ -124,7 +124,7 @@
 			background: var(--nav);
 			flex-direction: column;
 			position: absolute;
-			top: 3rem;
+			top: 2rem;
 			left: 0;
 			right: 0;
 			max-height: 0;
@@ -133,6 +133,7 @@
 		.navbar ul.open {
 			max-height: 500px;
 			padding-bottom: 1rem;
+			padding-top: 1rem;
 		}
 	}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,8 +51,9 @@
 </svelte:head>
 
 <Analytics />
+<a href="#main" class="skip-link">Skip to main content</a>
 <NavBar />
-<main>
+<main id="main">
 	<slot />
 </main>
 
@@ -68,12 +69,10 @@
 				Name:
 				<input autocomplete="name" type="text" bind:value={name} required />
 			</label>
-			<br />
 			<label>
 				Email:
 				<input autocomplete="email" type="email" bind:value={email} required />
 			</label>
-			<br />
 			<button type="submit">Subscribe</button>
 		</form>
 

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -80,13 +80,16 @@
 						{#each posts as post}
 							{@const name = getImageName(post.featuredImage.node.sourceUrl)}
 							<li class="photo-item">
-								<button onclick={() => openLightbox(post.featuredImage.node.sourceUrl, name)}>
+								<button
+									onclick={() => openLightbox(post.featuredImage.node.sourceUrl, name)}
+									aria-label="View full size: {name}"
+								>
 									<img
 										src={post.featuredImage.node.sourceUrl}
-										alt={post.title}
+										alt=""
 										loading="lazy"
 									/>
-									<span class="photo-name">{name}</span>
+									<span class="photo-name" aria-hidden="true">{name}</span>
 								</button>
 							</li>
 						{/each}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,6 +69,21 @@ main {
 	}
 }
 
+.skip-link {
+	position: absolute;
+	top: -100%;
+	left: 0;
+	background: #000;
+	color: #fff;
+	padding: 0.5rem 1rem;
+	z-index: 9999;
+	text-decoration: none;
+
+	&:focus {
+		top: 0;
+	}
+}
+
 button {
 	background-color: var(--nav);
 	color: var(--white);
@@ -77,6 +92,11 @@ button {
 	cursor: pointer;
 	font-family: var(--heading-font);
 	font-size: 1.5rem;
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
 }
 
 .page-container {


### PR DESCRIPTION
## Summary

- **Skip to main content link** (`+layout.svelte`, `global.css`): Added a visually hidden skip link before the navbar that becomes visible on focus. Target is `<main id="main">`. Keyboard users can now bypass navigation with a single Tab press.
- **Disabled button state** (`global.css`): Added `button:disabled { opacity: 0.6; cursor: not-allowed; }` so the submit button in AddComment is visually distinct while submitting.
- **Hamburger SVG icon** (`NavBar.svelte`): Replaced `☰` emoji with an inline SVG (`aria-hidden="true" focusable="false"`) — button's existing `aria-label` still provides the accessible name, but the icon now renders reliably regardless of emoji font availability.
- **Remove `<br>` layout tags** (`+layout.svelte`): Removed two `<br />` elements between footer form labels — the form is already `display: flex; flex-direction: column` so they were redundant.
- **Gallery photo button redundancy** (`gallery/+page.svelte`): Added `aria-label="View full size: {name}"` to each photo button. Set `alt=""` on the thumbnail image (decorative within the labelled button) and `aria-hidden="true"` on the `.photo-name` span, so screen readers announce a single clean label instead of image alt + span text.
- **`aria-required` on form fields** (`AddComment.svelte`): Added `aria-required="true"` alongside `required` on all three fields, providing an explicit signal to assistive technologies.

## Test plan

- [ ] Tab to the page — confirm "Skip to main content" link appears visually on first Tab press and activates correctly
- [ ] Submit comment form while submitting — confirm button appears visually greyed out
- [ ] Resize to mobile — confirm hamburger SVG renders and the button announces correctly via screen reader
- [ ] Navigate footer subscribe form via keyboard — confirm Name → Email → Subscribe tab order without unexpected pauses from `<br>` elements
- [ ] Open screen reader on gallery page — confirm each photo button announces "View full size: [name]" once, not image alt + span text
- [ ] Screen reader on comment form — confirm required fields are announced as required

🤖 Generated with [Claude Code](https://claude.com/claude-code)