### PR TITLE
chore(types): improve TypeScript typing across components and API layer

### DIFF
--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -2,7 +2,12 @@
 	import { tick } from 'svelte';
 	import { showAddComment } from '$lib/stores/commentState';
 
-	const { postId, parentCommentId = null } = $props();
+	interface Props {
+		postId: string;
+		parentCommentId?: string | null;
+	}
+
+	const { postId, parentCommentId = null }: Props = $props();
 
 	let name = $state('');
 	let email = $state('');

--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-
 	import { get } from 'svelte/store';
+	import type { Writable } from 'svelte/store';
 	import { sanitize } from '$lib/sanitize';
-import { showAddComment } from '$lib/stores/commentState';
+	import { showAddComment } from '$lib/stores/commentState';
 	import AddComment from './AddComment.svelte';
 	import Comment from './Comment.svelte';
+	import type { ThreadedComment } from '$lib/types';
 
-	const { comment, postId, replyForms } = $props();
+	interface Props {
+		comment: ThreadedComment;
+		postId: string;
+		replyForms: Writable<Record<string, boolean>>;
+	}
+
+	const { comment, postId, replyForms }: Props = $props();
 
 	const formatDate = (dateString: string) => {
 		const date = new Date(dateString);

--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { get } from 'svelte/store';
+	
 	import type { Writable } from 'svelte/store';
+import { get } from 'svelte/store';
 	import { sanitize } from '$lib/sanitize';
 	import { showAddComment } from '$lib/stores/commentState';
+	import type { ThreadedComment } from '$lib/types';
 	import AddComment from './AddComment.svelte';
 	import Comment from './Comment.svelte';
-	import type { ThreadedComment } from '$lib/types';
 
 	interface Props {
 		comment: ThreadedComment;

--- a/src/lib/components/Comments.svelte
+++ b/src/lib/components/Comments.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
 	import { writable } from 'svelte/store';
 	import Comment from './Comment.svelte';
+	import type { ThreadedComment } from '$lib/types';
 
-	const { threadedComments, postId } = $props();
+	interface Props {
+		threadedComments: ThreadedComment[];
+		postId: string;
+	}
+
+	const { threadedComments, postId }: Props = $props();
 
 	const replyForms = writable<{ [key: string]: boolean }>({});
 </script>

--- a/src/lib/components/Comments.svelte
+++ b/src/lib/components/Comments.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { writable } from 'svelte/store';
-	import Comment from './Comment.svelte';
 	import type { ThreadedComment } from '$lib/types';
+	import Comment from './Comment.svelte';
 
 	interface Props {
 		threadedComments: ThreadedComment[];

--- a/src/lib/graphql/api.ts
+++ b/src/lib/graphql/api.ts
@@ -1,6 +1,9 @@
 import ADD_COMMENT from '$lib/graphql/queries/addComment';
 
-export async function fetchGraphQL(query: string, variables = {}) {
+export async function fetchGraphQL<T = Record<string, unknown>>(
+	query: string,
+	variables: Record<string, unknown> = {}
+): Promise<T> {
 	const response = await fetch('https://blog.readingweather.co.uk/graphql', {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
@@ -15,8 +18,10 @@ export async function fetchGraphQL(query: string, variables = {}) {
 		throw new Error('Failed to fetch data');
 	}
 
-	return json.data;
+	return json.data as T;
 }
+
+type AddCommentResponse = { createComment: { success: boolean } | null };
 
 export async function addComment(
 	postId: number,
@@ -24,7 +29,7 @@ export async function addComment(
 	author: string,
 	authorEmail: string,
 	parentId: number | null = null
-) {
+): Promise<{ success: boolean }> {
 	const variables = {
 		input: {
 			commentOn: postId,
@@ -35,9 +40,7 @@ export async function addComment(
 		}
 	};
 
-	const response = await fetchGraphQL(ADD_COMMENT, variables);
+	const response = await fetchGraphQL<AddCommentResponse>(ADD_COMMENT, variables);
 
-	return response?.createComment
-		? { success: true, comment: response.createComment.comment }
-		: { success: false };
+	return { success: response.createComment?.success ?? false };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,9 @@
+export interface GqlComment {
+	id: string;
+	content: string;
+	parentId: string | null;
+	author: { node: { name: string } };
+	date: string;
+}
+
+export type ThreadedComment = GqlComment & { replies: ThreadedComment[] };

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -4,8 +4,8 @@
 	import Comments from '$lib/components/Comments.svelte';
 	import { sanitize } from '$lib/sanitize';
 	import { showAddComment } from '$lib/stores/commentState';
-	import type { PageProps } from '../[slug]/$types';
 	import type { GqlComment, ThreadedComment } from '$lib/types';
+	import type { PageProps } from '../[slug]/$types';
 
 	const { data }: PageProps = $props();
 

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -5,18 +5,9 @@
 	import { sanitize } from '$lib/sanitize';
 	import { showAddComment } from '$lib/stores/commentState';
 	import type { PageProps } from '../[slug]/$types';
+	import type { GqlComment, ThreadedComment } from '$lib/types';
 
 	const { data }: PageProps = $props();
-
-	interface GqlComment {
-		id: string;
-		content: string;
-		parentId: string | null;
-		author: { node: { name: string } };
-		date: string;
-	}
-
-	type ThreadedComment = GqlComment & { replies: ThreadedComment[] };
 
 	const organiseComments = (comments: GqlComment[]): ThreadedComment[] => {
 		const commentMap = new Map<string, ThreadedComment>();

--- a/src/routes/archives/+page.ts
+++ b/src/routes/archives/+page.ts
@@ -2,10 +2,13 @@ import { fetchGraphQL } from '../../lib/graphql/api';
 import GET_POSTS_BY_DATE from '../../lib/graphql/queries/getPostsByDate';
 import type { PageLoad } from '../$types';
 
-const generateArchives = () => {
+type ArchiveEntry = { year: number; month: number };
+type ArchivePost = { title: string; slug: string; date: string };
+
+const generateArchives = (): ArchiveEntry[] => {
 	const startYear = 2020;
 	const currentDate = new Date();
-	const archives = [];
+	const archives: ArchiveEntry[] = [];
 
 	for (let year = startYear; year <= currentDate.getFullYear(); year++) {
 		for (let month = 1; month <= 12; month++) {
@@ -23,9 +26,9 @@ export const load: PageLoad = async ({ url }) => {
 
 	const archives = generateArchives();
 
-	let posts = [];
+	let posts: ArchivePost[] = [];
 	if (selectedYear && selectedMonth) {
-		const postsRes = await fetchGraphQL(GET_POSTS_BY_DATE, {
+		const postsRes = await fetchGraphQL<{ posts: { nodes: ArchivePost[] } }>(GET_POSTS_BY_DATE, {
 			year: selectedYear,
 			month: selectedMonth
 		});

--- a/src/routes/gallery/+page.server.ts
+++ b/src/routes/gallery/+page.server.ts
@@ -18,9 +18,9 @@ type GroupedMonth = {
 	posts: GalleryPost[];
 };
 
-const generateYears = () => {
+const generateYears = (): number[] => {
 	const currentYear = new Date().getFullYear();
-	const years = [];
+	const years: number[] = [];
 	for (let year = currentYear; year >= START_YEAR; year--) {
 		years.push(year);
 	}
@@ -46,14 +46,17 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 
 	const monthResults = await Promise.all(
 		Array.from({ length: lastMonth }, (_, i) => i + 1).map((month) =>
-			fetchGraphQL(GET_POSTS_FOR_GALLERY, { year: selectedYear, month })
+			fetchGraphQL<{ posts: { nodes: GalleryPost[] } }>(GET_POSTS_FOR_GALLERY, {
+				year: selectedYear,
+				month
+			})
 		)
 	);
 
 	const groupedPosts: GroupedMonth[] = monthResults
 		.map((res, i) => {
 			const month = i + 1;
-			const posts = (res.posts.nodes as GalleryPost[]).filter((post) => {
+			const posts = res.posts.nodes.filter((post) => {
 				const sourceUrl = post.featuredImage?.node?.sourceUrl;
 				if (!sourceUrl) return false;
 				const filename = sourceUrl.split('/').pop() ?? '';


### PR DESCRIPTION
## Summary

Today is Monday so the focus is **TypeScript & typing**. No `any` was used anywhere in the codebase (good baseline), but several loose-typing patterns were found and fixed.

### Changes

- **`src/lib/types.ts`** (new) — Extracts `GqlComment` and `ThreadedComment` into a shared module so they can be imported by components rather than redefined in each file.

- **`src/lib/graphql/api.ts`**
  - `fetchGraphQL` is now generic (`fetchGraphQL<T = Record<string, unknown>>`) with `variables` typed as `Record<string, unknown>` instead of the implicit `{}`.
  - `addComment` has an explicit return type (`Promise<{ success: boolean }>`). The call to `fetchGraphQL` is now typed with `AddCommentResponse`, and the stale `.comment` property access (which referenced a field the mutation never actually returned) is removed.

- **`src/lib/components/AddComment.svelte`**, **`Comment.svelte`**, **`Comments.svelte`** — All now declare a typed `Props` interface and use it in `$props()`. `replyForms` is typed as `Writable<Record<string, boolean>>`, `comment` as `ThreadedComment`, etc.

- **`src/routes/[slug]/+page.svelte`** — Removes the locally-defined `GqlComment`/`ThreadedComment` duplicates and imports them from `$lib/types` instead.

- **`src/routes/archives/+page.ts`** — Adds `ArchiveEntry` and `ArchivePost` types; uses `fetchGraphQL<{ posts: { nodes: ArchivePost[] } }>` to replace the previously untyped response. Arrays initialised with explicit element types.

- **`src/routes/gallery/+page.server.ts`** — `generateYears` now has a `number[]` return type; the `Promise.all` map call uses `fetchGraphQL<{ posts: { nodes: GalleryPost[] } }>`, removing the manual `as GalleryPost[]` cast.

## Test plan

- [ ] Run `yarn build` (or `yarn check`) and confirm zero TypeScript errors
- [ ] Smoke-test the home page, a post page (comments visible), gallery, and archives in the dev server
- [ ] Verify comment submission still works end-to-end

https://claude.ai/code/session_018miocXTtc5zVMyahLNdVow