### PR TITLE
feat: add "On This Day in Reading Weather History" section to home page

### DIFF
--- a/src/lib/graphql/queries/getPostsByDay.ts
+++ b/src/lib/graphql/queries/getPostsByDay.ts
@@ -1,0 +1,13 @@
+const GET_POSTS_BY_DAY = `
+  query GetPostsByDay($year: Int!, $month: Int!, $day: Int!) {
+    posts(where: { dateQuery: { year: $year, month: $month, day: $day } }) {
+      nodes {
+        title
+        slug
+        date
+      }
+    }
+  }
+`;
+
+export default GET_POSTS_BY_DAY;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,3 +7,9 @@ export interface GqlComment {
 }
 
 export type ThreadedComment = GqlComment & { replies: ThreadedComment[] };
+
+export interface HistoricalPost {
+	title: string;
+	slug: string;
+	date: string;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,19 @@
 
 	import '../styles/index.css';
 	import PostList from '$lib/components/PostList.svelte';
+
+	function formatYear(dateString: string): string {
+		return new Intl.DateTimeFormat('en-GB', {
+			timeZone: 'Europe/London',
+			year: 'numeric'
+		}).format(new Date(dateString));
+	}
+
+	const todayFormatted = new Intl.DateTimeFormat('en-GB', {
+		timeZone: 'Europe/London',
+		day: 'numeric',
+		month: 'long'
+	}).format(new Date());
 </script>
 
 <svelte:head>
@@ -19,6 +32,21 @@
 <h1>Weather Forecast For Reading & Berkshire</h1>
 
 <PostList posts={data.posts.posts.nodes} />
+
+{#if data.historicalPosts.length > 0}
+	<section class="on-this-day">
+		<h2>On this day in Reading Weather history</h2>
+		<p class="on-this-day-intro">{todayFormatted} in previous years:</p>
+		<ul class="on-this-day-list">
+			{#each data.historicalPosts as post (post.slug)}
+				<li>
+					<span class="on-this-day-year">{formatYear(post.date)}</span>
+					<a href="/{post.slug}">{post.title}</a>
+				</li>
+			{/each}
+		</ul>
+	</section>
+{/if}
 
 <div class="older-posts">
 	<p>Looking for older posts?</p>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,9 +1,48 @@
 import { fetchGraphQL } from '$lib/graphql/api';
 import ALL_POSTS_QUERY from '$lib/graphql/queries/allPosts';
+import GET_POSTS_BY_DAY from '$lib/graphql/queries/getPostsByDay';
+import type { HistoricalPost } from '$lib/types';
 import type { PageLoad } from './$types';
 
+type PostsByDayResult = { posts: { nodes: HistoricalPost[] } };
+
+const SITE_START_YEAR = 2020;
+
+function getUKDate(): { year: number; month: number; day: number } {
+	const now = new Date();
+	const parts = new Intl.DateTimeFormat('en-GB', {
+		timeZone: 'Europe/London',
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric'
+	}).formatToParts(now);
+
+	const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? 0);
+	return { year: get('year'), month: get('month'), day: get('day') };
+}
+
 export const load: PageLoad = async () => {
-	const posts = await fetchGraphQL(ALL_POSTS_QUERY);
+	const { year: currentYear, month, day } = getUKDate();
+
+	const yearsToCheck = Array.from(
+		{ length: currentYear - SITE_START_YEAR },
+		(_, i) => SITE_START_YEAR + i
+	);
+
+	const [posts, historicalResults] = await Promise.all([
+		fetchGraphQL(ALL_POSTS_QUERY),
+		Promise.all(
+			yearsToCheck.map((year) =>
+				fetchGraphQL<PostsByDayResult>(GET_POSTS_BY_DAY, { year, month, day }).catch(() => ({
+					posts: { nodes: [] as HistoricalPost[] }
+				}))
+			)
+		)
+	]);
+
+	const historicalPosts = historicalResults
+		.flatMap((r) => r.posts.nodes)
+		.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
 	const meta = {
 		title: 'Weather Forecast For Reading & Berkshire',
@@ -11,5 +50,5 @@ export const load: PageLoad = async () => {
 			'Your local, human-written weather forecast – especially for people in Reading and the surrounding areas'
 	};
 
-	return { posts, meta };
+	return { posts, historicalPosts, meta };
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -86,6 +86,59 @@ main {
 	}
 }
 
+.on-this-day {
+	text-align: center;
+	margin: 0 0 2rem 0;
+	border: 3px solid var(--nav);
+	padding: 1rem 1.5rem;
+	background: #eef2f7;
+
+	h2 {
+		margin-top: 0;
+		color: var(--nav);
+	}
+
+	.on-this-day-intro {
+		font-style: italic;
+		margin-bottom: 1rem;
+		color: var(--text-color);
+	}
+
+	.on-this-day-list {
+		list-style: none;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		margin-bottom: 0;
+
+		li {
+			display: flex;
+			gap: 0.75rem;
+			align-items: baseline;
+			justify-content: center;
+			flex-wrap: wrap;
+		}
+
+		.on-this-day-year {
+			font-family: var(--heading-font);
+			font-size: 1.3rem;
+			font-weight: bold;
+			color: var(--nav);
+			min-width: 3rem;
+		}
+
+		a {
+			color: var(--text-color);
+			text-decoration: underline;
+
+			&:hover {
+				color: var(--nav);
+			}
+		}
+	}
+}
+
 .older-posts {
 	text-align: center;
 	margin: 0 0 2rem 0;


### PR DESCRIPTION
## Summary

This adds a **"On This Day in Reading Weather History"** section to the home page — a daily-changing feature that surfaces posts from the same calendar date in previous years, giving visitors a compelling reason to bookmark the site and return regularly.

### Why this feature?

A weather site's most valuable long-term asset is its historical archive. Surfacing that history in a time-sensitive, serendipitous way ("what was the weather like on this exact day last year?") is a low-effort, high-engagement pattern proven by news sites and weather services alike. It costs nothing extra but makes every visit slightly different and worth sharing.

### What changed

- **`src/lib/graphql/queries/getPostsByDay.ts`** — New GraphQL query that filters posts by `year`, `month`, and `day` using WPGraphQL's `dateQuery` support (the same mechanism already used by the archives page).
- **`src/lib/types.ts`** — Added `HistoricalPost` interface (`title`, `slug`, `date`) used by the new query result and component.
- **`src/routes/+page.ts`** — The home page `load` function now:
  - Resolves the correct UK date using `Intl.DateTimeFormat` with `Europe/London` timezone (handles BST/GMT correctly regardless of server timezone)
  - Fires parallel GraphQL requests for each year from 2020 to last year alongside the existing main posts fetch
  - Silently catches per-year failures so a single year's query error never blocks the page
  - Returns `historicalPosts[]` sorted most-recent-year first
- **`src/routes/+page.svelte`** — Conditionally renders the new section below the current posts (only when at least one historical post exists). Displays year prominently in the site's heading font alongside a link to the post.
- **`src/styles/index.css`** — Styled to match the existing palette: `--nav` blue-gray border and year label, `#eef2f7` background tint, hover colour transition on links.

### Behaviour

- Section is **invisible on days with no matching historical posts** — no empty state to maintain
- All historical requests are **parallel and non-blocking** — if the WordPress backend is slow or a year returns an error, the rest of the page is unaffected
- Works correctly on days that span UTC/BST midnight (e.g. a UK visitor at 23:30 BST won't see yesterday's history)

## Test plan

- [ ] Visit the home page and confirm the "On This Day" section appears when historical posts exist for today's date
- [ ] Confirm the section is absent (no empty box) on dates with no historical posts
- [ ] Confirm each link navigates to the correct post
- [ ] Confirm the year label and post title display correctly
- [ ] Confirm the section does not affect the existing current-forecast posts above it
- [ ] Check mobile layout — year and title should wrap cleanly on narrow screens

https://claude.ai/code/session_015iAsJNdQtghMB9oJBH4rhj

---
_Generated by [Claude Code](https://claude.ai/code/session_015iAsJNdQtghMB9oJBH4rhj)_