### PR TITLE
fix(typescript): remove unsafe type assertions and add explicit GraphQL response types

### DIFF
--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -11,16 +11,13 @@
 
 	const organiseComments = (comments: GqlComment[]): ThreadedComment[] => {
 		const commentMap = new Map<string, ThreadedComment>();
-		const threaded = comments as ThreadedComment[];
-		// biome-ignore lint/complexity/noForEach: <explanation>
-		threaded.forEach((comment) => {
-			comment.replies = [];
+		const threaded: ThreadedComment[] = comments.map((c) => ({ ...c, replies: [] }));
+		for (const comment of threaded) {
 			commentMap.set(comment.id, comment);
-		});
+		}
 
 		const topLevelComments: ThreadedComment[] = [];
-		// biome-ignore lint/complexity/noForEach: <explanation>
-		threaded.forEach((comment) => {
+		for (const comment of threaded) {
 			if (comment.parentId) {
 				const parent = commentMap.get(comment.parentId);
 				if (parent) {
@@ -29,7 +26,7 @@
 			} else {
 				topLevelComments.push(comment);
 			}
-		});
+		}
 
 		return topLevelComments;
 	};

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -10,8 +10,8 @@
 	const { data }: PageProps = $props();
 
 	const organiseComments = (comments: GqlComment[]): ThreadedComment[] => {
-		const commentMap = new Map<string, ThreadedComment>(threaded.map((c) => [c.id, c]));
 		const threaded: ThreadedComment[] = comments.map((c) => ({ ...c, replies: [] }));
+		const commentMap = new Map<string, ThreadedComment>(threaded.map((c) => [c.id, c]));
 		for (const comment of threaded) {
 			commentMap.set(comment.id, comment);
 		}
@@ -35,8 +35,7 @@
 	const postId = data.post.id;
 
 	const postDescription =
-		data.post.excerpt ||
-		`Weather Forecast For Reading & Berkshire, issued ${data.post.title}`;
+		data.post.excerpt || `Weather Forecast For Reading & Berkshire, issued ${data.post.title}`;
 	const postTitle = `Weather Forecast For Reading & Berkshire, issued ${data.post.title}`;
 	const postUrl = `https://www.readingweather.co.uk/${data.post.slug}`;
 

--- a/src/routes/sitemap-2.xml/+server.ts
+++ b/src/routes/sitemap-2.xml/+server.ts
@@ -32,12 +32,14 @@ function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priorit
     </url>`;
 }
 
+type SitemapNode = { slug: string; date: string | null };
+
 export const GET: RequestHandler = async () => {
 	const base = 'https://www.readingweather.co.uk';
 
 	try {
-		const data = await fetchGraphQL(ALL_POSTS_SITEMAP_QUERY);
-		const nodes = data?.posts?.nodes || [];
+		const data = await fetchGraphQL<{ posts: { nodes: SitemapNode[] } }>(ALL_POSTS_SITEMAP_QUERY);
+		const nodes = data.posts.nodes;
 
 		const staticRoutes = [
 			{ path: '/', changefreq: 'daily', priority: '1.0' },

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -32,12 +32,14 @@ function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priorit
     </url>`;
 }
 
+type SitemapNode = { slug: string; date: string | null };
+
 export const GET: RequestHandler = async () => {
 	const base = 'https://www.readingweather.co.uk';
 
 	try {
-		const data = await fetchGraphQL(ALL_POSTS_SITEMAP_QUERY);
-		const nodes = data?.posts?.nodes || [];
+		const data = await fetchGraphQL<{ posts: { nodes: SitemapNode[] } }>(ALL_POSTS_SITEMAP_QUERY);
+		const nodes = data.posts.nodes;
 
 		const staticRoutes = [
 			{ path: '/', changefreq: 'daily', priority: '1.0' },


### PR DESCRIPTION
## Summary

Three targeted TypeScript fixes identified during a type-safety audit of the codebase (strict mode is enabled, so these are quality/correctness improvements rather than compiler errors).

### Changes

**`src/routes/[slug]/+page.svelte` — `organiseComments` function**

The function was casting `GqlComment[]` to `ThreadedComment[]` using `as`, then immediately mutating each element to add a `replies` property. This is unsafe: `ThreadedComment` requires `replies: ThreadedComment[]` but the cast happens before that property is initialised, meaning the objects are briefly in an invalid state.

Replaced with `.map((c) => ({ ...c, replies: [] }))` which creates properly-typed `ThreadedComment` objects from the start. This also let us replace both `forEach` calls (which carried `biome-ignore lint/complexity/noForEach` suppressions) with `for...of` loops.

**`src/routes/sitemap.xml/+server.ts` and `src/routes/sitemap-2.xml/+server.ts` — `fetchGraphQL` call**

Both sitemap handlers called `fetchGraphQL` without a type parameter, leaving the return type as the loose `Record<string, unknown>` default. Data was then accessed via unsafe optional chaining (`data?.posts?.nodes || []`) with no TypeScript verification of the shape.

Added a local `SitemapNode = { slug: string; date: string | null }` type and passed it as `fetchGraphQL<{ posts: { nodes: SitemapNode[] } }>`. This lets TypeScript verify that `node.slug` and `node.date` are the correct types throughout the sitemap-building loop, and removes the defensive `?.` optional chaining that was masking the lack of typing.

## Test plan

- [ ] Run `yarn check` (svelte-check) — no new type errors
- [ ] Load a post page and verify comments thread correctly
- [ ] Fetch `/sitemap.xml` and `/sitemap-2.xml` — both return valid XML with post URLs

https://claude.ai/code/session_01FyQbDYVpYHVomTBN9NPP9s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyQbDYVpYHVomTBN9NPP9s)_