### PR TITLE
test: add unit tests for historicalWeather, archives load, and historical-weather endpoint

### DIFF
--- a/src/lib/api/historicalWeather.spec.ts
+++ b/src/lib/api/historicalWeather.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchHistoricalWeather } from './historicalWeather';
 
 function makeWeatherResponse() {

--- a/src/lib/api/historicalWeather.spec.ts
+++ b/src/lib/api/historicalWeather.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { fetchHistoricalWeather } from './historicalWeather';
+
+function makeWeatherResponse() {
+	return {
+		ok: true,
+		json: async () => ({
+			daily: {
+				temperature_2m_max: [22.456],
+				temperature_2m_min: [14.123],
+				precipitation_sum: [3.789],
+				wind_speed_10m_max: [18.321]
+			},
+			hourly: {
+				// hours 00-05 (pre-morning), 06-11 (morning: partly cloudy=2),
+				// 12-17 (afternoon: overcast=3), 18-23 (evening: mainly clear=1)
+				weather_code: [0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1]
+			}
+		})
+	};
+}
+
+describe('fetchHistoricalWeather', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeWeatherResponse()));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns exactly 6 years of data', async () => {
+		const results = await fetchHistoricalWeather(6, 15);
+		expect(results).toHaveLength(6);
+	}, 3000);
+
+	it('sorts results by year in descending order', async () => {
+		const results = await fetchHistoricalWeather(1, 1);
+		for (let i = 0; i < results.length - 1; i++) {
+			expect(results[i].year).toBeGreaterThan(results[i + 1].year);
+		}
+	}, 3000);
+
+	it('rounds temperature, precipitation, and wind speed to one decimal place', async () => {
+		const [first] = await fetchHistoricalWeather(1, 1);
+		// Math.round(22.456 * 10) / 10 = 22.5, etc.
+		expect(first.tempMax).toBe(22.5);
+		expect(first.tempMin).toBe(14.1);
+		expect(first.precipitation).toBe(3.8);
+		expect(first.windSpeedMax).toBe(18.3);
+	}, 3000);
+
+	it('silently omits years where the API request failed', async () => {
+		let calls = 0;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation(async () => {
+				calls++;
+				if (calls === 1) return { ok: false, status: 500 };
+				return makeWeatherResponse();
+			})
+		);
+		const results = await fetchHistoricalWeather(1, 1);
+		expect(results).toHaveLength(5);
+	}, 3000);
+});

--- a/src/routes/api/historical-weather/server.spec.ts
+++ b/src/routes/api/historical-weather/server.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GET } from './+server';
+
+vi.mock('$lib/api/historicalWeather', () => ({
+	fetchHistoricalWeather: vi.fn().mockResolvedValue([
+		{
+			year: 2025,
+			tempMax: 20,
+			tempMin: 10,
+			precipitation: 5,
+			windSpeedMax: 15,
+			conditions: { morning: 'clear sky', afternoon: 'partly cloudy', evening: 'mainly clear' }
+		}
+	])
+}));
+
+function makeEvent(params: Record<string, string> = {}) {
+	const url = new URL('http://localhost/api/historical-weather');
+	for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+	return { url } as Parameters<typeof GET>[0];
+}
+
+describe('GET /api/historical-weather', () => {
+	it('returns 400 with an error message when month or day is missing', async () => {
+		const response = await GET(makeEvent({ month: '6' }));
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe('month and day are required');
+	});
+
+	it('returns 200 with weather data when both month and day are provided', async () => {
+		const response = await GET(makeEvent({ month: '6', day: '15' }));
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(Array.isArray(body)).toBe(true);
+		expect(body[0].year).toBe(2025);
+	});
+});

--- a/src/routes/archives/page.spec.ts
+++ b/src/routes/archives/page.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+function makeUrl(params: Record<string, string> = {}) {
+	const url = new URL('http://localhost/archives');
+	for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+	return url;
+}
+
+describe('archives load — generateArchives', () => {
+	it('does not include any month beyond the current date', async () => {
+		const { archives } = await load({ url: makeUrl() } as Parameters<typeof load>[0]);
+		const now = new Date();
+		const future = archives.filter(
+			(a) =>
+				a.year > now.getFullYear() ||
+				(a.year === now.getFullYear() && a.month > now.getMonth() + 1)
+		);
+		expect(future).toHaveLength(0);
+	});
+
+	it('returns archive entries in reverse chronological order', async () => {
+		const { archives } = await load({ url: makeUrl() } as Parameters<typeof load>[0]);
+		for (let i = 0; i < archives.length - 1; i++) {
+			const current = archives[i].year * 12 + archives[i].month;
+			const next = archives[i + 1].year * 12 + archives[i + 1].month;
+			expect(current).toBeGreaterThan(next);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds 8 new Vitest unit tests across three previously untested modules, raising total test count from 19 to 27.

- **`src/lib/api/historicalWeather.spec.ts`** (4 tests): covers the 6-year fetch range, descending sort order, one-decimal rounding of temperature/precipitation/wind speed, and graceful omission of years where the Open-Meteo API returns an error (exercising the `Promise.allSettled` resilience path). Uses a stubbed `fetch` global to avoid real network calls; accepts the real 300 ms inter-batch delay (well within Vitest's default timeout).

- **`src/routes/archives/page.spec.ts`** (2 tests): verifies that `generateArchives` never produces an entry beyond the current month (boundary guard), and that all entries are returned in strict reverse chronological order. Calls the `load` function directly with a URL that has no search params, so `fetchGraphQL` is never invoked.

- **`src/routes/api/historical-weather/server.spec.ts`** (2 tests): asserts that the `GET` handler returns `400` with a descriptive error body when `month` or `day` is absent, and `200` with the mocked weather array when both params are present. Mocks `$lib/api/historicalWeather` to keep the test fast and isolated.

## Test plan

- [x] `yarn test:unit --run` passes with 27/27 tests across 7 test files
- [x] No SvelteKit `+`-prefix warnings on the new spec files
- [x] All pre-existing 19 tests remain green

https://claude.ai/code/session_016En55kCJnUnxDoxofXCnwK

---
_Generated by [Claude Code](https://claude.ai/code/session_016En55kCJnUnxDoxofXCnwK)_