### PR TITLE
chore: improve TypeScript typing across components and routes

### DIFF
--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -16,9 +16,9 @@
 	let errorMessage = $state('');
 	let successMessage = $state('');
 
-	async function submitComment(event: Event) {
+	async function submitComment(event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }): Promise<void> {
 		event.preventDefault();
-		const form = event.target as HTMLFormElement;
+		const form = event.currentTarget;
 		submitting = true;
 		errorMessage = '';
 		successMessage = '';

--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -16,7 +16,7 @@ import { get } from 'svelte/store';
 
 	const { comment, postId, replyForms }: Props = $props();
 
-	const formatDate = (dateString: string) => {
+	const formatDate = (dateString: string): string => {
 		const date = new Date(dateString);
 		const options: Intl.DateTimeFormatOptions = {
 			year: 'numeric',
@@ -26,7 +26,7 @@ import { get } from 'svelte/store';
 		const formattedDate = date.toLocaleDateString('en-US', options);
 
 		const day = date.getDate();
-		const ordinalSuffix = (day: number) => {
+		const ordinalSuffix = (day: number): 'st' | 'nd' | 'rd' | 'th' => {
 			if (day > 3 && day < 21) return 'th';
 			switch (day % 10) {
 				case 1:
@@ -49,7 +49,7 @@ import { get } from 'svelte/store';
 		return `${formattedDate.replace(/\d+/, day + ordinalSuffix(day))} at ${formattedTime}`;
 	};
 
-	const toggleReplyForm = (commentId: string) => {
+	const toggleReplyForm = (commentId: string): void => {
 		replyForms.update((currentForms) => ({
 			[commentId]: !currentForms[commentId]
 		}));
@@ -71,7 +71,7 @@ import { get } from 'svelte/store';
 		</ul>
 	{/if}
 
-	<button class="reply-button" on:click={() => toggleReplyForm(comment?.id)}>Reply</button>
+	<button class="reply-button" onclick={() => toggleReplyForm(comment?.id)}>Reply</button>
 
 	{#if $replyForms[comment?.id]}
 		<AddComment {postId} parentCommentId={comment.id} />

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -16,7 +16,7 @@
 		};
 	}>;
 
-	const modifyContent = (content: string) => {
+	const modifyContent = (content: string): string => {
 		const paragraphs = content.split(/<\/?p>/).filter((p) => p.trim() !== '');
 
 		const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='wffrb'></iframe>`;

--- a/src/lib/stores/commentState.ts
+++ b/src/lib/stores/commentState.ts
@@ -1,3 +1,3 @@
-import { writable, type Writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 
 export const showAddComment: Writable<boolean> = writable(true);

--- a/src/lib/stores/commentState.ts
+++ b/src/lib/stores/commentState.ts
@@ -1,3 +1,3 @@
-import { writable } from 'svelte/store';
+import { writable, type Writable } from 'svelte/store';
 
-export const showAddComment = writable(true);
+export const showAddComment: Writable<boolean> = writable(true);

--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -4,8 +4,8 @@
 
 	const { data }: PageProps = $props();
 
-	const updateArchive = (event: Event) => {
-		const selected = (event.target as HTMLSelectElement).value;
+	const updateArchive = (event: Event & { currentTarget: EventTarget & HTMLSelectElement }): void => {
+		const selected = event.currentTarget.value;
 		if (!selected) return;
 		const [year, month] = selected.split('-');
 		window.location.href = `archives/?year=${year}&month=${month}`;
@@ -43,7 +43,7 @@
 <article class="post">
 	<div class="archive-container">
 		<label for="archive-select">Select Month:</label>
-		<select id="archive-select" on:change={updateArchive}>
+		<select id="archive-select" onchange={updateArchive}>
 			<option value="">-- Select --</option>
 			{#each data.archives as archive}
 				<option

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -9,8 +9,8 @@
 		'July', 'August', 'September', 'October', 'November', 'December'
 	];
 
-	const updateYear = (event: Event) => {
-		const selected = (event.target as HTMLSelectElement).value;
+	const updateYear = (event: Event & { currentTarget: EventTarget & HTMLSelectElement }): void => {
+		const selected = event.currentTarget.value;
 		if (!selected) return;
 		window.location.href = `gallery?year=${selected}`;
 	};

--- a/src/routes/sitemap-2.xml/+server.ts
+++ b/src/routes/sitemap-2.xml/+server.ts
@@ -21,7 +21,7 @@ function escapeXml(value: string): string {
 		.replace(/'/g, '&apos;');
 }
 
-function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priority = '0.7') {
+function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priority = '0.7'): string {
 	const last = lastmod ? `<lastmod>${escapeXml(lastmod)}</lastmod>` : '';
 	return `
     <url>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -21,7 +21,7 @@ function escapeXml(value: string): string {
 		.replace(/'/g, '&apos;');
 }
 
-function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priority = '0.7') {
+function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priority = '0.7'): string {
 	const last = lastmod ? `<lastmod>${escapeXml(lastmod)}</lastmod>` : '';
 	return `
     <url>


### PR DESCRIPTION
## Summary

Today's automated quality pass: **TypeScript & typing** (Sunday random pick → category 1).

The project already has `strict: true` and zero `any` usage — this PR tightens up the remaining loose spots.

### Changes

- **Explicit return type annotations** added to helper functions that were missing them:
  - `toXmlUrl` in both sitemap server files → `: string`
  - `formatDate` in `Comment.svelte` → `: string`
  - `ordinalSuffix` in `Comment.svelte` → `'st' | 'nd' | 'rd' | 'th'` (precise union, not just `string`)
  - `modifyContent` in `PostList.svelte` → `: string`
  - `toggleReplyForm` in `Comment.svelte` → `: void`
  - `updateYear` in `gallery/+page.svelte` → `: void`
  - `updateArchive` in `archives/+page.svelte` → `: void`

- **Eliminate unsafe `event.target` casts** in `updateYear` and `updateArchive`: replaced `(event.target as HTMLSelectElement).value` with `event.currentTarget.value` after typing the handler as `Event & { currentTarget: EventTarget & HTMLSelectElement }`. Svelte 5 narrows `currentTarget` correctly for the element, so no cast is needed.

- **`AddComment.svelte` `submitComment`**: typed as `SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }` (was `Event`) and uses `event.currentTarget` directly instead of `event.target as HTMLFormElement`.

- **Svelte 5 event directive migration**:
  - `archives/+page.svelte`: `on:change` → `onchange` (the rest of the codebase already uses Svelte 5 syntax)
  - `Comment.svelte`: `on:click` → `onclick` (removes the deprecation warning reported by `svelte-check`)

- **`commentState.ts`**: explicit `Writable<boolean>` annotation on `showAddComment` so the type is stated at the definition site rather than inferred.

## Test plan

- [ ] `yarn run check` passes with no new errors or warnings in the changed files (pre-existing errors in `photographs`, `seasonal-forecasts`, `useful-links` and the `gallery` template are unchanged)
- [ ] Archives page: month/year select still navigates correctly
- [ ] Gallery page: year select still filters by year correctly
- [ ] Comment reply button still opens the reply form
- [ ] Add-comment form still submits and resets correctly

https://claude.ai/code/session_01EiWa429bqAeS4qPsUkABNB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiWa429bqAeS4qPsUkABNB)_