### PR TITLE
fix(types): resolve all 70 TypeScript errors (Monday typing pass)

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,11 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	interface Window {
+		gtag: (command: string, ...args: unknown[]) => void;
+		dataLayer: unknown[];
+	}
 }
 
 export {};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,3 +7,103 @@ export interface GqlComment {
 }
 
 export type ThreadedComment = GqlComment & { replies: ThreadedComment[] };
+
+export interface GqlPostFeaturedImageNode {
+	sourceUrl: string;
+	srcSet?: string;
+	mediaDetails?: {
+		width?: number;
+		height?: number;
+	};
+}
+
+export interface GqlPostNode {
+	id: string;
+	title: string;
+	slug: string;
+	excerpt?: string;
+	date: string;
+	content: string;
+	featuredImage?: {
+		node?: GqlPostFeaturedImageNode;
+	};
+	comments?: {
+		nodes: GqlComment[];
+	};
+}
+
+export interface GqlPageSeo {
+	description: string;
+	opengraphDescription: string;
+}
+
+export interface GqlPageNode {
+	title: string;
+	slug: string;
+	content: string;
+	seo: GqlPageSeo;
+	featuredImage?: {
+		node?: {
+			sourceUrl: string;
+		};
+	};
+}
+
+export interface AllPostsResponse {
+	posts: {
+		nodes: Array<{
+			date: string;
+			slug: string;
+			title: string;
+			content: string;
+			featuredImage?: {
+				node?: {
+					sourceUrl: string;
+					srcSet: string;
+					mediaDetails?: { height?: number };
+				};
+			};
+		}>;
+	};
+}
+
+export interface GetPostBySlugResponse {
+	posts: {
+		nodes: Array<{ slug: string }>;
+	};
+	postBy: GqlPostNode | null;
+}
+
+export interface GetPageByIdResponse {
+	page: GqlPageNode | null;
+}
+
+export interface SeasonalPostsResponse {
+	posts: {
+		nodes: Array<{
+			date: string;
+			slug: string;
+			title: string;
+			content: string;
+			featuredImage?: {
+				node?: {
+					sourceUrl: string;
+					srcSet: string;
+				};
+			};
+			comments?: {
+				nodes: GqlComment[];
+			};
+		}>;
+	};
+}
+
+export interface OnThisDayResponse {
+	posts: {
+		nodes: Array<{
+			title: string;
+			slug: string;
+			date: string;
+		}>;
+	};
+}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,7 @@
 import { fetchGraphQL } from '$lib/graphql/api';
 import ALL_POSTS_QUERY from '$lib/graphql/queries/allPosts';
 import GET_POSTS_ON_THIS_DAY from '$lib/graphql/queries/getPostsOnThisDay';
+import type { AllPostsResponse, OnThisDayResponse } from '$lib/types';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
@@ -9,8 +10,8 @@ export const load: PageLoad = async () => {
 	const day = today.getDate();
 
 	const [posts, onThisDay] = await Promise.all([
-		fetchGraphQL(ALL_POSTS_QUERY),
-		fetchGraphQL(GET_POSTS_ON_THIS_DAY, { month, day }).catch(() => null)
+		fetchGraphQL<AllPostsResponse>(ALL_POSTS_QUERY),
+		fetchGraphQL<OnThisDayResponse>(GET_POSTS_ON_THIS_DAY, { month, day }).catch(() => null)
 	]);
 
 	const meta = {

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -32,7 +32,7 @@
 		return topLevelComments;
 	};
 
-	const threadedComments = organiseComments(data.post.comments.nodes);
+	const threadedComments = organiseComments(data.post.comments?.nodes ?? []);
 	const postId = data.post.id;
 
 	const postDescription =

--- a/src/routes/[slug]/+page.ts
+++ b/src/routes/[slug]/+page.ts
@@ -1,11 +1,18 @@
+import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_POST_BY_SLUG from '$lib/graphql/queries/getPostBySlug';
+import type { GetPostBySlugResponse } from '$lib/types';
 import type { PageLoad } from '../[slug]/$types';
 
 export const load: PageLoad = async ({ params }) => {
 	const { slug } = params;
 
-	const response = await fetchGraphQL(GET_POST_BY_SLUG, { slug });
+	const response = await fetchGraphQL<GetPostBySlugResponse>(GET_POST_BY_SLUG, { slug });
+
+	if (!response.postBy) {
+		throw error(404, 'Post not found');
+	}
+
 	const latestSlug = response.posts?.nodes?.[0]?.slug;
 
 	return {

--- a/src/routes/about/+page.ts
+++ b/src/routes/about/+page.ts
@@ -1,12 +1,18 @@
+import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_PAGE_BY_ID from '$lib/graphql/queries/getPageById';
+import type { GetPageByIdResponse } from '$lib/types';
 import type { PageLoad } from './$types';
 
 export const prerender = true;
 
 export const load: PageLoad = async () => {
 	const pageId = 2;
-	const response = await fetchGraphQL(GET_PAGE_BY_ID, { id: pageId });
+	const response = await fetchGraphQL<GetPageByIdResponse>(GET_PAGE_BY_ID, { id: pageId });
+
+	if (!response.page) {
+		throw error(404, 'Page not found');
+	}
 
 	return { page: response.page };
 };

--- a/src/routes/gallery/+page.server.ts
+++ b/src/routes/gallery/+page.server.ts
@@ -13,9 +13,16 @@ type GalleryPost = {
 	featuredImage?: { node?: { sourceUrl: string } };
 };
 
+type GalleryPostWithImage = {
+	title: string;
+	slug: string;
+	date: string;
+	featuredImage: { node: { sourceUrl: string } };
+};
+
 type GroupedMonth = {
 	month: number;
-	posts: GalleryPost[];
+	posts: GalleryPostWithImage[];
 };
 
 const generateYears = (): number[] => {
@@ -56,7 +63,7 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const groupedPosts: GroupedMonth[] = monthResults
 		.map((res, i) => {
 			const month = i + 1;
-			const posts = res.posts.nodes.filter((post) => {
+			const posts = res.posts.nodes.filter((post): post is GalleryPostWithImage => {
 				const sourceUrl = post.featuredImage?.node?.sourceUrl;
 				if (!sourceUrl) return false;
 				const filename = sourceUrl.split('/').pop() ?? '';

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -30,7 +30,7 @@
 
 	let lightboxUrl = $state('');
 	let lightboxName = $state('');
-	let lightboxDialog = $state<HTMLDialogElement | null>(null);
+	let lightboxDialog = $state<HTMLDivElement | null>(null);
 	let triggerButton = $state<HTMLButtonElement | null>(null);
 
 	const openLightbox = (url: string, name: string, btn: HTMLButtonElement) => {

--- a/src/routes/photographs/+page.ts
+++ b/src/routes/photographs/+page.ts
@@ -1,12 +1,18 @@
+import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_PAGE_BY_ID from '$lib/graphql/queries/getPageById';
+import type { GetPageByIdResponse } from '$lib/types';
 import type { PageLoad } from './$types';
 
 export const prerender = true;
 
 export const load: PageLoad = async () => {
 	const pageId = 169;
-	const response = await fetchGraphQL(GET_PAGE_BY_ID, { id: pageId });
+	const response = await fetchGraphQL<GetPageByIdResponse>(GET_PAGE_BY_ID, { id: pageId });
+
+	if (!response.page) {
+		throw error(404, 'Page not found');
+	}
 
 	return { page: response.page };
 };

--- a/src/routes/seasonal-forecasts/+page.svelte
+++ b/src/routes/seasonal-forecasts/+page.svelte
@@ -12,11 +12,11 @@
 	<meta name="description" content="Seasonal forecasts for Reading & Berkshire." />
 	<meta property="og:title" content="Seasonal Forecasts" />
 	<meta property="og:description" content="Seasonal forecasts for Reading & Berkshire." />
-	{#if data.posts.featuredImage?.node?.sourceUrl}
-		<meta property="og:image" content={data.posts.featuredImage.node.sourceUrl} />
+	{#if data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl}
+		<meta property="og:image" content={data.posts.posts.nodes[0].featuredImage.node.sourceUrl} />
 	{/if}
 	<meta property="og:type" content="article" />
-	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.posts.slug}`} />
+	<meta property="og:url" content="https://www.readingweather.co.uk/seasonal-forecasts" />
 </svelte:head>
 
 <h1>Seasonal Forecasts</h1>

--- a/src/routes/seasonal-forecasts/+page.ts
+++ b/src/routes/seasonal-forecasts/+page.ts
@@ -1,9 +1,10 @@
 import { fetchGraphQL } from '$lib/graphql/api';
 import ALL_SEASONAL_POSTS_QUERY from '$lib/graphql/queries/allSeasonalPosts';
-import type { PageLoad } from '../$types';
+import type { SeasonalPostsResponse } from '$lib/types';
+import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-	const posts = await fetchGraphQL(ALL_SEASONAL_POSTS_QUERY);
+	const posts = await fetchGraphQL<SeasonalPostsResponse>(ALL_SEASONAL_POSTS_QUERY);
 
 	return { posts };
 };

--- a/src/routes/useful-links/+page.ts
+++ b/src/routes/useful-links/+page.ts
@@ -1,12 +1,18 @@
+import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_PAGE_BY_ID from '$lib/graphql/queries/getPageById';
+import type { GetPageByIdResponse } from '$lib/types';
 import type { PageLoad } from './$types';
 
 export const prerender = true;
 
 export const load: PageLoad = async () => {
 	const pageId = 161;
-	const response = await fetchGraphQL(GET_PAGE_BY_ID, { id: pageId });
+	const response = await fetchGraphQL<GetPageByIdResponse>(GET_PAGE_BY_ID, { id: pageId });
+
+	if (!response.page) {
+		throw error(404, 'Page not found');
+	}
 
 	return { page: response.page };
 };


### PR DESCRIPTION
## Summary

`svelte-check` was reporting **70 TypeScript errors** across 12 files. This PR fixes all of them, bringing the error count to zero.

### Root cause

Almost all errors traced back to `fetchGraphQL()` being called without a type parameter, causing it to fall back to `Record<string, unknown>`. SvelteKit's type-generation then propagated `unknown` into every `PageData` / `PageProps`, causing cascading "is of type unknown" and "Property X does not exist on type '{}'" errors throughout the templates.

### Changes

| File | What changed |
|------|-------------|
| `src/lib/types.ts` | Added typed GraphQL response interfaces: `AllPostsResponse`, `GetPostBySlugResponse`, `GetPageByIdResponse`, `SeasonalPostsResponse`, `OnThisDayResponse`, plus supporting node types (`GqlPostNode`, `GqlPageNode`, `GqlPostFeaturedImageNode`, `GqlPageSeo`) |
| `src/app.d.ts` | Added `Window.gtag` and `Window.dataLayer` declarations to fix analytics errors |
| `src/routes/+page.ts` | Added `AllPostsResponse` / `OnThisDayResponse` type params to `fetchGraphQL` |
| `src/routes/[slug]/+page.ts` | Added `GetPostBySlugResponse` type param; throw `error(404)` when `postBy` is null to narrow the template type to non-null |
| `src/routes/[slug]/+page.svelte` | Use `data.post.comments?.nodes ?? []` — `comments` is optional in the GQL type |
| `src/routes/about/+page.ts` | Added `GetPageByIdResponse` type param; throw `error(404)` when `page` is null |
| `src/routes/photographs/+page.ts` | Same as above |
| `src/routes/useful-links/+page.ts` | Same as above |
| `src/routes/seasonal-forecasts/+page.ts` | Added `SeasonalPostsResponse` type param; fixed `PageLoad` import from `'../$types'` → `'./$types'` |
| `src/routes/seasonal-forecasts/+page.svelte` | Fixed OG `<meta>` tags: replaced non-existent `data.posts.featuredImage` / `data.posts.slug` with correct path `data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl` and a static OG URL |
| `src/routes/gallery/+page.server.ts` | Added `GalleryPostWithImage` type; used type predicate `(post): post is GalleryPostWithImage` in the filter so downstream template sees non-optional `featuredImage` |
| `src/routes/gallery/+page.svelte` | Fixed `lightboxDialog` from `HTMLDialogElement \| null` → `HTMLDivElement \| null` (the bound element is a `<div>`, not a `<dialog>`) |

## Test plan

- [x] `svelte-check` passes with **0 errors** (was 70)
- [ ] Verify gallery lightbox opens and closes correctly
- [ ] Verify seasonal-forecasts OG tags render the first post image
- [ ] Verify 404 is served for unknown post slugs

---
_Generated by [Claude Code](https://claude.ai/code/session_018tnKRsogPEtxd7svUZU2dc)_