### PR TITLE
test: add unit tests for GraphQL client and home page load

### DIFF
--- a/src/lib/graphql/api.spec.ts
+++ b/src/lib/graphql/api.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchGraphQL, addComment } from './api';
+
+describe('fetchGraphQL', () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ data: { posts: { nodes: [] } } })
+			})
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('resolves with the data property on a successful response', async () => {
+		const expected = { posts: { nodes: [{ id: '1' }] } };
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ data: expected })
+			})
+		);
+
+		const result = await fetchGraphQL('{ posts { nodes { id } } }');
+
+		expect(result).toEqual(expected);
+	});
+
+	it('throws when the HTTP response is not ok', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: false,
+				json: async () => ({ errors: [{ message: 'Server error' }] })
+			})
+		);
+
+		await expect(fetchGraphQL('{ posts { nodes { id } } }')).rejects.toThrow(
+			'Failed to fetch data'
+		);
+	});
+
+	it('throws when the response contains GraphQL errors even if HTTP status is ok', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ errors: [{ message: 'Field not found' }], data: null })
+			})
+		);
+
+		await expect(fetchGraphQL('{ nonexistent }')).rejects.toThrow('Failed to fetch data');
+	});
+});
+
+describe('addComment', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns { success: true } when the mutation succeeds', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ data: { createComment: { success: true } } })
+			})
+		);
+
+		const result = await addComment(123, 'Great post!', 'Alice', 'alice@example.com');
+
+		expect(result).toEqual({ success: true });
+	});
+
+	it('returns { success: false } when createComment is null in the response', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ data: { createComment: null } })
+			})
+		);
+
+		const result = await addComment(123, 'Hello', 'Bob', 'bob@example.com');
+
+		expect(result).toEqual({ success: false });
+	});
+});

--- a/src/lib/graphql/api.spec.ts
+++ b/src/lib/graphql/api.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchGraphQL, addComment } from './api';
+import { addComment, fetchGraphQL } from './api';
 
 describe('fetchGraphQL', () => {
 	beforeEach(() => {

--- a/src/routes/page.spec.ts
+++ b/src/routes/page.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+const mockPosts = { posts: { nodes: [{ date: '2026-01-01', slug: 'test', title: 'Test', content: '' }] } };
+const mockOnThisDay = { posts: { nodes: [{ title: 'Old post', slug: 'old-post', date: '2020-06-02' }] } };
+
+describe('home page load', () => {
+	it('returns posts, onThisDay, and meta', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce(mockPosts).mockResolvedValueOnce(mockOnThisDay);
+
+		const result = await load({} as Parameters<typeof load>[0]);
+
+		expect(result).toMatchObject({
+			posts: mockPosts,
+			onThisDay: mockOnThisDay,
+			meta: expect.objectContaining({ title: expect.any(String), description: expect.any(String) })
+		});
+	});
+
+	it('sets the correct page title in meta', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce(mockPosts).mockResolvedValueOnce(mockOnThisDay);
+
+		const { meta } = await load({} as Parameters<typeof load>[0]);
+
+		expect(meta.title).toBe('Weather Forecast For Reading & Berkshire');
+	});
+
+	it('returns null for onThisDay when the query throws', async () => {
+		vi.mocked(fetchGraphQL)
+			.mockResolvedValueOnce(mockPosts)
+			.mockRejectedValueOnce(new Error('Not found'));
+
+		const { onThisDay } = await load({} as Parameters<typeof load>[0]);
+
+		expect(onThisDay).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- **`src/lib/graphql/api.spec.ts`** (5 new tests): covers `fetchGraphQL` and `addComment` — the core data-fetching functions used across every page. Tests verify: success path resolves with `response.data`; non-OK HTTP status throws; GraphQL `errors` in the body throws; `addComment` maps `createComment.success` correctly; `addComment` returns `{ success: false }` when `createComment` is `null`.
- **`src/routes/page.spec.ts`** (3 new tests): covers the home page `load` function. Tests verify: the return shape includes `posts`, `onThisDay`, and `meta`; `meta.title` is set to the expected string; a failing `onThisDay` query is caught and returned as `null` rather than rejecting the whole load.

## Why these areas

`fetchGraphQL` is called by every `+page.ts` load function in the project, so correctness bugs there affect every route. The `addComment` null-response edge case was unguarded and could silently return misleading state. The home page `load` is the site's entry point and the `onThisDay` silent-catch behaviour was untested despite being the only place the function suppresses errors.

All 35 tests pass (27 pre-existing + 8 new).

## Test plan

- [x] `./node_modules/.bin/vitest run` — 35/35 tests pass
- [ ] Verify CI passes on this PR

https://claude.ai/code/session_016X4v5S82yG4B3tRickKycb

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4v5S82yG4B3tRickKycb)_