### PR TITLE
perf: fix image CLS on home page and precompute gallery names

### DIFF
--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -10,6 +10,7 @@
 				sourceUrl: string;
 				srcSet: string;
 				mediaDetails?: {
+					width?: number;
 					height?: number;
 				};
 			};
@@ -37,8 +38,9 @@
 						<img
 							src={post.featuredImage.node.sourceUrl}
 							srcset={post.featuredImage.node.srcSet}
+							sizes="(min-width: 768px) 700px, 100vw"
 							alt=""
-							width="200"
+							width={post.featuredImage.node.mediaDetails?.width ?? undefined}
 							height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 							loading="lazy"
 						/>

--- a/src/lib/graphql/queries/allPosts.ts
+++ b/src/lib/graphql/queries/allPosts.ts
@@ -10,6 +10,7 @@ const ALL_POSTS_QUERY = `
             sourceUrl(size: MEDIUM_LARGE)
             srcSet(size: MEDIUM_LARGE)
             mediaDetails {
+              width
               height
             }
           }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,7 +60,7 @@ export interface AllPostsResponse {
 				node?: {
 					sourceUrl: string;
 					srcSet: string;
-					mediaDetails?: { height?: number };
+					mediaDetails?: { width?: number; height?: number };
 				};
 			};
 		}>;

--- a/src/routes/gallery/+page.server.ts
+++ b/src/routes/gallery/+page.server.ts
@@ -13,17 +13,37 @@ type GalleryPost = {
 	featuredImage?: { node?: { sourceUrl: string } };
 };
 
-type GalleryPostWithImage = {
+type GalleryPostFiltered = {
 	title: string;
 	slug: string;
 	date: string;
 	featuredImage: { node: { sourceUrl: string } };
 };
 
+export type GalleryPostWithImage = GalleryPostFiltered & { name: string };
+
 type GroupedMonth = {
 	month: number;
 	posts: GalleryPostWithImage[];
 };
+
+function getImageName(url: string): string {
+	const filename = url.split('/').pop()?.split('?')[0] ?? '';
+	const nameWithoutExt = filename.replace(/\.[^/.]+$/, '');
+	return nameWithoutExt
+		.split(/[-_\s]+/)
+		.filter(
+			(word) =>
+				!/^\d+$/.test(word) &&
+				!/^jpe?g$/i.test(word) &&
+				!/^png$/i.test(word) &&
+				!/^webp$/i.test(word)
+		)
+		.map((word) => word.replace(/\d+$/, ''))
+		.filter((word) => word.length > 0)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
+}
 
 const generateYears = (): number[] => {
 	const currentYear = new Date().getFullYear();
@@ -63,12 +83,17 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const groupedPosts: GroupedMonth[] = monthResults
 		.map((res, i) => {
 			const month = i + 1;
-			const posts = res.posts.nodes.filter((post): post is GalleryPostWithImage => {
-				const sourceUrl = post.featuredImage?.node?.sourceUrl;
-				if (!sourceUrl) return false;
-				const filename = sourceUrl.split('/').pop() ?? '';
-				return !/PXL/i.test(filename);
-			});
+			const posts = res.posts.nodes
+				.filter((post): post is GalleryPostFiltered => {
+					const sourceUrl = post.featuredImage?.node?.sourceUrl;
+					if (!sourceUrl) return false;
+					const filename = sourceUrl.split('/').pop() ?? '';
+					return !/PXL/i.test(filename);
+				})
+				.map((post): GalleryPostWithImage => ({
+					...post,
+					name: getImageName(post.featuredImage.node.sourceUrl)
+				}));
 			return { month, posts };
 		})
 		.filter(({ posts }) => posts.length > 0)

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -15,19 +15,6 @@
 		window.location.href = `gallery?year=${selected}`;
 	};
 
-	const getImageName = (url: string): string => {
-		const filename = url.split('/').pop()?.split('?')[0] ?? '';
-		const nameWithoutExt = filename.replace(/\.[^/.]+$/, '');
-		return nameWithoutExt
-			.split(/[-_\s]+/)
-			// Remove purely numeric segments (e.g. trailing numbers like "tina-2")
-			.filter((word) => !/^\d+$/.test(word) && !/^jpe?g$/i.test(word) && !/^png$/i.test(word) && !/^webp$/i.test(word))
-			.map((word) => word.replace(/\d+$/, ''))
-			.filter((word) => word.length > 0)
-			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-			.join(' ');
-	};
-
 	let lightboxUrl = $state('');
 	let lightboxName = $state('');
 	let lightboxDialog = $state<HTMLDivElement | null>(null);
@@ -89,15 +76,14 @@
 					<h2>{monthNames[month - 1]} {data.selectedYear}</h2>
 					<ul class="photo-grid">
 						{#each posts as post}
-							{@const name = getImageName(post.featuredImage.node.sourceUrl)}
 							<li class="photo-item">
-								<button onclick={(e) => openLightbox(post.featuredImage.node.sourceUrl, name, e.currentTarget as HTMLButtonElement)} aria-label="View full size: {name}">
+								<button onclick={(e) => openLightbox(post.featuredImage.node.sourceUrl, post.name, e.currentTarget as HTMLButtonElement)} aria-label="View full size: {post.name}">
 									<img
 										src={post.featuredImage.node.sourceUrl}
 										alt=""
 										loading="lazy"
 									/>
-									<span class="photo-name" aria-hidden="true">{name}</span>
+									<span class="photo-name" aria-hidden="true">{post.name}</span>
 								</button>
 							</li>
 						{/each}


### PR DESCRIPTION
## Summary

Performance & SvelteKit optimisation pass (Wednesday category).

### Problem 1 — CLS on the home page (`PostList.svelte`)

The `allPosts` GraphQL query was only fetching `mediaDetails { height }` but the `<img>` had a hardcoded `width="200"`. The browser had no way to compute the correct aspect ratio before the image loaded, causing Cumulative Layout Shift every time the home page loaded.

**Fix:**
- Added `width` to the `mediaDetails` field in `allPosts.ts` (matching the pattern already used by the `[slug]` page query).
- Replaced `width="200"` with `width={mediaDetails?.width}` so the browser receives the natural image dimensions and can reserve the right height before the image arrives.
- Added `sizes="(min-width: 768px) 700px, 100vw"` (consistent with `[slug]/+page.svelte`) so the browser picks an appropriately-sized srcset candidate instead of always assuming 100vw.
- Updated `AllPostsResponse` in `types.ts` and the inline prop type in `PostList.svelte` to include `width?: number`.

### Problem 2 — Per-render regex work in gallery template

`getImageName()` (a chain of `split`, `filter`, `map`, and regex tests) was defined in `+page.svelte` and called via `{@const name = getImageName(...)}` inside a nested `{#each}` loop — once per image on every render.

**Fix:**
- Moved `getImageName()` to `+page.server.ts` where it now runs once per page load (and effectively once per hour thanks to the existing in-memory cache).
- Added a `name` field to `GalleryPostWithImage`; each post object now carries its precomputed display name.
- The gallery template simply reads `post.name` — no function calls in the render path.

## Test plan

- [ ] Home page images: confirm `<img>` elements carry `width`, `height`, and `sizes` attributes in the rendered HTML
- [ ] Gallery page: confirm `post.name` values appear correctly as photo captions and in button `aria-label` attributes
- [ ] Run `yarn vitest run` — all 35 unit tests should pass (verified locally before push)
- [ ] Visually check home page and gallery for layout regressions

https://claude.ai/code/session_01KcJHouYSyDoEgPeiqwkShC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcJHouYSyDoEgPeiqwkShC)_