### PR TITLE
Replace inline colour styles with scoped CSS classes in AddComment

### DIFF
--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -70,6 +70,16 @@
 			{submitting ? 'Submitting...' : 'Post Comment'}
 		</button>
 	{/if}
-	<p role="alert" aria-live="assertive" style="color: red;">{errorMessage}</p>
-	<p role="status" aria-live="polite" style="color: green;">{successMessage}</p>
+	<p role="alert" aria-live="assertive" class="error-message">{errorMessage}</p>
+	<p role="status" aria-live="polite" class="success-message">{successMessage}</p>
 </form>
+
+<style>
+	.error-message {
+		color: red;
+	}
+
+	.success-message {
+		color: green;
+	}
+</style>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes `style="color: red;"` and `style="color: green;"` inline attributes from the error and success message paragraphs in `AddComment.svelte`
- Replaces them with `.error-message` and `.success-message` scoped CSS classes, consistent with the project's styling convention

## Test plan

- [ ] Submit a comment with invalid data and confirm the error message still appears in red
- [ ] Submit a valid comment and confirm the success message still appears in green

https://claude.ai/code/session_01A8nwQYDn8cvNsndFua5S1N
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8nwQYDn8cvNsndFua5S1N)_