### PR TITLE
chore(a11y): fix accessibility and SEO issues

### DIFF
--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -70,6 +70,30 @@
 			{submitting ? 'Submitting...' : 'Post Comment'}
 		</button>
 	{/if}
-	<p role="alert" aria-live="assertive" style="color: red;">{errorMessage}</p>
-	<p role="status" aria-live="polite" style="color: green;">{successMessage}</p>
+	<p role="alert" aria-live="assertive" class="form-message form-message--error">{errorMessage}</p>
+	<p role="status" aria-live="polite" class="form-message form-message--success">{successMessage}</p>
 </form>
+
+<style>
+	.form-message {
+		min-height: 1.5em;
+	}
+
+	.form-message--error {
+		color: #c0392b;
+		font-weight: 600;
+	}
+
+	.form-message--error:not(:empty)::before {
+		content: 'Error: ';
+	}
+
+	.form-message--success {
+		color: #1a7c3a;
+		font-weight: 600;
+	}
+
+	.form-message--success:not(:empty)::before {
+		content: 'Success: ';
+	}
+</style>

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -20,7 +20,7 @@
 	const modifyContent = (content: string): string => {
 		const paragraphs = content.split(/<\/?p>/).filter((p) => p.trim() !== '');
 
-		const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='wffrb'></iframe>`;
+		const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='Support Reading Weather on Ko-fi'></iframe>`;
 		if (paragraphs.length > 2) {
 			paragraphs.splice(-3, 0, iframeHTML);
 		}
@@ -39,7 +39,7 @@
 							src={post.featuredImage.node.sourceUrl}
 							srcset={post.featuredImage.node.srcSet}
 							sizes="(min-width: 768px) 700px, 100vw"
-							alt=""
+							alt={post.title}
 							width={post.featuredImage.node.mediaDetails?.width ?? undefined}
 							height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 							loading="lazy"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -65,13 +65,13 @@
 			test messages until I'm satisfied it is working!
 		</p>
 		<form id="subscribe-form" onsubmit={handleSubmit}>
-			<label>
+			<label for="subscribe-name">
 				Name:
-				<input autocomplete="name" type="text" bind:value={name} required />
+				<input id="subscribe-name" autocomplete="name" type="text" bind:value={name} required />
 			</label>
-			<label>
+			<label for="subscribe-email">
 				Email:
-				<input autocomplete="email" type="email" bind:value={email} required />
+				<input id="subscribe-email" autocomplete="email" type="email" bind:value={email} required />
 			</label>
 			<button type="submit">Subscribe</button>
 		</form>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,6 +13,8 @@
 	<meta name="description" content={data.meta.description} />
 	<meta property="og:title" content={data.meta.title} />
 	<meta property="og:description" content={data.meta.description} />
+	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/" />
 </svelte:head>

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -64,7 +64,7 @@
 
 	const paragraphs = data.post.content.split(/<\/?p>/).filter((p) => p.trim() !== '');
 
-	const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='wffrb'></iframe>`;
+	const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='Support Reading Weather on Ko-fi'></iframe>`;
 	if (paragraphs.length > 2) {
 		paragraphs.splice(-3, 0, iframeHTML);
 	}

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -80,7 +80,7 @@
 								<button onclick={(e) => openLightbox(post.featuredImage.node.sourceUrl, post.name, e.currentTarget as HTMLButtonElement)} aria-label="View full size: {post.name}">
 									<img
 										src={post.featuredImage.node.sourceUrl}
-										alt=""
+										alt={post.name}
 										loading="lazy"
 									/>
 									<span class="photo-name" aria-hidden="true">{post.name}</span>


### PR DESCRIPTION
## Summary

Thursday's automated accessibility & SEO pass. Six files changed across three categories of issues:

### Images — missing / empty alt text (WCAG 2.1 Level A)
- **PostList.svelte**: Featured image inside an `<a>` link had `alt=""`. Because the image is the only visual content of the link, screen readers would announce nothing. Changed to `alt={post.title}`.
- **gallery/+page.svelte**: Thumbnail images inside `<button>` elements had `alt=""`. Changed to `alt={post.name}` so the image content is described independently of the button's `aria-label`.

### Forms — feedback not conveyed by text alone (WCAG 1.4.1)
- **AddComment.svelte**: Error and success messages used `style="color: red/green"` as the only visual indicator. Replaced with CSS classes (`form-message--error` / `form-message--success`) that add a bold `"Error: "` / `"Success: "` prefix via `::before`, ensuring the state is communicated without relying on colour alone.
- **+layout.svelte**: Subscribe form inputs lacked explicit `id` attributes, relying on implicit label wrapping only. Added `id="subscribe-name"` and `id="subscribe-email"` with matching `for` attributes on the labels for more robust assistive-technology support.

### SEO — missing Open Graph / social sharing metadata
- **+page.svelte (home)**: Home page had no `og:image` or `twitter:image`, so social shares showed no preview image. Added both tags pointing to the existing static `/images/weather.png`.
- **PostList.svelte & [slug]/+page.svelte**: Ko-fi iframe `title` was set to `"wffrb"` (the account slug), which is meaningless to screen reader users. Changed to `"Support Reading Weather on Ko-fi"`.

## Test plan
- [ ] Screen-reader smoke test on the post list — confirm featured image alt is announced
- [ ] Screen-reader smoke test on gallery — confirm thumbnail alt is announced
- [ ] Submit the comment form with an error and confirm "Error: …" prefix is visible
- [ ] Check social share preview for the home page includes the weather image
- [ ] Inspect Ko-fi iframe with DevTools — confirm title attribute is descriptive

https://claude.ai/code/session_011RZr4Y5b9qpTE9bLmXKreR

---
_Generated by [Claude Code](https://claude.ai/code/session_011RZr4Y5b9qpTE9bLmXKreR)_