### PR TITLE
fix(a11y): hide mobile nav links from keyboard when menu is closed

### DIFF
--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -32,7 +32,7 @@
 	<ul
 		id="nav-menu"
 		class:open={isOpen}
-		style="transition: {isOpen ? 'max-height 0.3s ease-out' : 'none'};"
+		style="transition: {isOpen ? 'max-height 0.3s ease-out, visibility 0s 0s' : 'max-height 0.3s ease-out, visibility 0s 0.3s'};"
 	>
 		{#each links as link}
 			<li class:active={$page.url.pathname === link.href}>
@@ -128,12 +128,14 @@
 			left: 0;
 			right: 0;
 			max-height: 0;
+			visibility: hidden;
 		}
 
 		.navbar ul.open {
 			max-height: 500px;
 			padding-bottom: 1rem;
 			padding-top: 1rem;
+			visibility: visible;
 		}
 	}
 </style>


### PR DESCRIPTION
## Accessibility improvement

**Category:** Focus management
**WCAG criterion:** 2.1.1 Keyboard (A)
**File:** `src/lib/components/NavBar.svelte`
**Issue:** The mobile nav menu uses `max-height: 0` to visually hide nav links when closed, but they remain in the tab order, allowing keyboard users to focus invisible links.
**Fix:** Added `visibility: hidden` to the closed mobile nav state and `visibility: visible` to the open state. Updated the inline `transition` to delay visibility becoming hidden until after the `max-height` collapse animation completes (0.3s), so the visual transition is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)