### PR TITLE
refactor: extract Ko-fi widget injection into shared helper

### DIFF
--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { sanitize } from '$lib/sanitize';
+	import { injectKofiWidget } from '$lib/kofi';
 
 	export let posts: Array<{
 		slug: string;
@@ -16,17 +17,6 @@
 			};
 		};
 	}>;
-
-	const modifyContent = (content: string): string => {
-		const paragraphs = content.split(/<\/?p>/).filter((p) => p.trim() !== '');
-
-		const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='Support Reading Weather on Ko-fi'></iframe>`;
-		if (paragraphs.length > 2) {
-			paragraphs.splice(-3, 0, iframeHTML);
-		}
-
-		return paragraphs.map((p) => `<p>${p}</p>`).join('');
-	};
 </script>
 
 <ul>
@@ -47,7 +37,7 @@
 					{/if}
 					<h2>{post.title}</h2>
 				</a>
-				<div class="content">{@html sanitize(modifyContent(post.content))}</div>
+				<div class="content">{@html sanitize(injectKofiWidget(post.content))}</div>
 				<div class="comment-link">
 					<a href="/{post.slug}#comments" aria-label="View or add a comment on {post.title}">View or add a comment</a>
 				</div>

--- a/src/lib/kofi.ts
+++ b/src/lib/kofi.ts
@@ -1,0 +1,9 @@
+const KOFI_IFRAME_HTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='Support Reading Weather on Ko-fi'></iframe>`;
+
+export function injectKofiWidget(content: string): string {
+	const paragraphs = content.split(/<\/?p>/).filter((p) => p.trim() !== '');
+	if (paragraphs.length > 2) {
+		paragraphs.splice(-3, 0, KOFI_IFRAME_HTML);
+	}
+	return paragraphs.map((p) => `<p>${p}</p>`).join('');
+}

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -3,6 +3,7 @@
 	import AddComment from '$lib/components/AddComment.svelte';
 	import Comments from '$lib/components/Comments.svelte';
 	import ShareButton from '$lib/components/ShareButton.svelte';
+	import { injectKofiWidget } from '$lib/kofi';
 	import { sanitize } from '$lib/sanitize';
 	import { showAddComment } from '$lib/stores/commentState';
 	import type { GqlComment, ThreadedComment } from '$lib/types';
@@ -62,14 +63,7 @@
 		}
 	};
 
-	const paragraphs = data.post.content.split(/<\/?p>/).filter((p) => p.trim() !== '');
-
-	const iframeHTML = `<iframe id='kofiframe' src='https://ko-fi.com/wffrb/?hidefeed=true&widget=true&embed=true&preview=true' style='border:none;width:100%;padding:4px;background:#f9f9f9;' height='612' title='Support Reading Weather on Ko-fi'></iframe>`;
-	if (paragraphs.length > 2) {
-		paragraphs.splice(-3, 0, iframeHTML);
-	}
-
-	const modifiedContent = paragraphs.map((p) => `<p>${p}</p>`).join('');
+	const modifiedContent = injectKofiWidget(data.post.content);
 
 	const hoursOld = $derived((new Date().getTime() - new Date(data.post.date).getTime()) / 36e5);
 	const daysOld = $derived(Math.floor(hoursOld / 24));


### PR DESCRIPTION
## Summary

**Category:** Code duplication  
**Issue:** The Ko-fi iframe HTML string and paragraph-splice injection logic were copy-pasted verbatim in both `PostList.svelte` and `[slug]/+page.svelte`.  
**Fix:** Extracted both into `src/lib/kofi.ts` as `injectKofiWidget(content: string): string`. Both call sites now import and use the shared helper — one source of truth for the widget URL, inline styles, and injection position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)