### PR TITLE
chore: remove scaffold demo spec

### DIFF
--- a/src/demo.spec.ts
+++ b/src/demo.spec.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest';
-
-describe('sum test', () => {
-	it('adds 1 + 2 to equal 3', () => {
-		expect(1 + 2).toBe(3);
-	});
-});


### PR DESCRIPTION
## Summary

**Category:** Dead code
**Issue:** `src/demo.spec.ts` contained a Vitest scaffold placeholder (`expect(1 + 2).toBe(3)`) that was never replaced with real project tests, adding noise to the test suite and inflating the test file count.
**Fix:** File deleted. All 34 meaningful unit tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)