### PR TITLE
test: add unit tests for slug loader, photographs loader, and hooks handler

### DIFF
--- a/src/hooks.server.spec.ts
+++ b/src/hooks.server.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handle } from './hooks.server';
+
+function makeEvent(pathname: string) {
+	return { url: new URL(`http://localhost${pathname}`) };
+}
+
+function makeResolve() {
+	return vi.fn().mockResolvedValue(new Response('ok'));
+}
+
+describe('hooks handle', () => {
+	it('sets X-Frame-Options: SAMEORIGIN on all responses', async () => {
+		const response = await handle({
+			event: makeEvent('/any-page') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		expect(response.headers.get('X-Frame-Options')).toBe('SAMEORIGIN');
+	});
+
+	it('sets a short-lived cache-control for the homepage', async () => {
+		const response = await handle({
+			event: makeEvent('/') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		expect(response.headers.get('cache-control')).toBe(
+			'public, max-age=300, stale-while-revalidate=60'
+		);
+	});
+
+	it('sets a longer cache-control for the seasonal-forecasts page', async () => {
+		const response = await handle({
+			event: makeEvent('/seasonal-forecasts') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		expect(response.headers.get('cache-control')).toBe(
+			'public, max-age=3600, stale-while-revalidate=300'
+		);
+	});
+});

--- a/src/routes/[slug]/page.spec.ts
+++ b/src/routes/[slug]/page.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+const mockPost = {
+	id: '1',
+	title: 'Test Post',
+	slug: 'test-post',
+	content: '<p>Content</p>',
+	date: '2026-01-01',
+	seo: { description: 'A test post', opengraphDescription: 'OG description' }
+};
+
+describe('[slug] page load', () => {
+	it('returns post data and isLatest=true when slug matches the newest post', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			postBy: mockPost,
+			posts: { nodes: [{ slug: 'test-post' }] }
+		});
+
+		const result = await load({ params: { slug: 'test-post' } } as Parameters<typeof load>[0]);
+
+		expect(result.post).toEqual(mockPost);
+		expect(result.isLatest).toBe(true);
+		expect(result.latestSlug).toBe('test-post');
+	});
+
+	it('returns isLatest=false when the slug is not the newest post', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			postBy: mockPost,
+			posts: { nodes: [{ slug: 'newer-post' }] }
+		});
+
+		const result = await load({ params: { slug: 'test-post' } } as Parameters<typeof load>[0]);
+
+		expect(result.isLatest).toBe(false);
+		expect(result.latestSlug).toBe('newer-post');
+	});
+
+	it('throws a 404 error when postBy is null', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			postBy: null,
+			posts: { nodes: [] }
+		});
+
+		await expect(
+			load({ params: { slug: 'missing-post' } } as Parameters<typeof load>[0])
+		).rejects.toMatchObject({ status: 404 });
+	});
+});

--- a/src/routes/photographs/page.spec.ts
+++ b/src/routes/photographs/page.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+const mockPage = {
+	title: 'Photographs',
+	slug: 'photographs',
+	content: '<p>A gallery of weather photographs from Reading.</p>',
+	seo: { description: 'Weather photographs', opengraphDescription: 'OG photos' }
+};
+
+describe('photographs page load', () => {
+	it('returns page data when the WordPress page exists', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ page: mockPage });
+
+		const result = await load({} as Parameters<typeof load>[0]);
+
+		expect(result.page).toEqual(mockPage);
+	});
+
+	it('throws a 404 error when the page is not found', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ page: null });
+
+		await expect(load({} as Parameters<typeof load>[0])).rejects.toMatchObject({ status: 404 });
+	});
+});


### PR DESCRIPTION
## Summary

- **`src/routes/[slug]/page.spec.ts`** (3 tests): verifies that the dynamic post loader returns the correct post data, correctly computes `isLatest` when the slug matches or doesn't match the newest post, and throws a 404 error when `postBy` is null.
- **`src/routes/photographs/page.spec.ts`** (2 tests): verifies that the photographs page loader returns page data from the GraphQL response and throws a 404 when the page is not found.
- **`src/hooks.server.spec.ts`** (3 tests): verifies that the SvelteKit hooks handler injects the `X-Frame-Options: SAMEORIGIN` security header on all responses, and sets the correct short-lived cache-control for the homepage and the longer TTL for `/seasonal-forecasts`.

Test count goes from **35 → 43** across **9 → 12** spec files. All existing tests continue to pass.

## Why these areas

The slug loader is the most-visited route on the site and had no test coverage at all — the `isLatest` flag and the 404 branch were completely unverified. The photographs loader is a prerendered page with a hard-coded page ID, making a 404 a silent risk. The hooks handler enforces security headers on every single response, so regressions there affect the whole site; testing the cache-control per-path logic also guards against accidental misconfiguration.

## Test plan

- [x] `yarn test:unit --run` passes all 43 tests locally
- [x] New tests follow the same `vi.mock` + `vi.mocked` pattern already used in the project
- [x] No new dependencies required

https://claude.ai/code/session_014U1VrYEu4dMBmw3f7SYqc9

---
_Generated by [Claude Code](https://claude.ai/code/session_014U1VrYEu4dMBmw3f7SYqc9)_