### PR TITLE
test: add unit tests for gallery load, sanitize, about page, and sitemap

### DIFF
--- a/src/lib/sanitize.spec.ts
+++ b/src/lib/sanitize.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { sanitize } from './sanitize';
+
+describe('sanitize', () => {
+	it('returns HTML unchanged in SSR context where DOMPurify requires a DOM', () => {
+		const html = '<p>Hello <strong>world</strong><script>alert(1)</script></p>';
+		expect(sanitize(html)).toBe(html);
+	});
+});

--- a/src/routes/about/page.spec.ts
+++ b/src/routes/about/page.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GqlPageNode } from '$lib/types';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+const mockPage: GqlPageNode = {
+	title: 'About',
+	slug: 'about',
+	content: '<p>About the site</p>',
+	seo: { description: 'About Reading Weather', opengraphDescription: 'About OG' }
+};
+
+describe('about page load', () => {
+	it('returns the page when fetchGraphQL resolves a page', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ page: mockPage });
+
+		const result = await load({} as Parameters<typeof load>[0]);
+
+		expect(result).toEqual({ page: mockPage });
+	});
+
+	it('throws a 404 error when fetchGraphQL returns no page', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ page: null });
+
+		await expect(load({} as Parameters<typeof load>[0])).rejects.toMatchObject({ status: 404 });
+	});
+});

--- a/src/routes/gallery/page.spec.ts
+++ b/src/routes/gallery/page.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { load } from './+page.server';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn(),
+	setCache: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+import { getCache } from '$lib/server/cache';
+
+type GalleryPost = { slug: string; name: string };
+type GalleryGroup = { month: number; posts: GalleryPost[] };
+type GalleryLoadResult = { years: number[]; selectedYear: number; groupedPosts: GalleryGroup[] };
+
+function makeEvent(params: Record<string, string> = {}) {
+	const url = new URL('http://localhost/gallery');
+	for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+	return { url, setHeaders: vi.fn() } as unknown as Parameters<typeof load>[0];
+}
+
+function makePost(slug: string, sourceUrl: string, date = '2023-01-01') {
+	return { title: slug, slug, date, featuredImage: { node: { sourceUrl } } };
+}
+
+describe('gallery load', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns cached data without calling fetchGraphQL when a cache hit exists', async () => {
+		const cached: GalleryGroup[] = [{ month: 6, posts: [] }];
+		vi.mocked(getCache).mockReturnValueOnce(cached);
+
+		const result = (await load(makeEvent({ year: '2023' }))) as GalleryLoadResult;
+
+		expect(result.groupedPosts).toBe(cached);
+		expect(fetchGraphQL).not.toHaveBeenCalled();
+	});
+
+	it('filters out posts whose image filename contains PXL and derives names from remaining URLs', async () => {
+		vi.mocked(getCache).mockReturnValue(null);
+		vi.mocked(fetchGraphQL).mockResolvedValue({
+			posts: {
+				nodes: [
+					makePost('pxl-post', 'https://example.com/PXL_20230101.jpg'),
+					makePost('sunny-day', 'https://example.com/sunny-day-2023.jpg')
+				]
+			}
+		});
+
+		const result = (await load(makeEvent({ year: '2023' }))) as GalleryLoadResult;
+
+		result.groupedPosts.forEach(({ posts }) => {
+			expect(posts.every((p) => p.slug !== 'pxl-post')).toBe(true);
+		});
+		expect(result.groupedPosts[0].posts[0].name).toBe('Sunny Day');
+	});
+
+	it('returns all non-empty months sorted in descending order for a past year', async () => {
+		vi.mocked(getCache).mockReturnValue(null);
+		vi.mocked(fetchGraphQL).mockResolvedValue({
+			posts: {
+				nodes: [makePost('some-post', 'https://example.com/photo.jpg')]
+			}
+		});
+
+		const result = (await load(makeEvent({ year: '2023' }))) as GalleryLoadResult;
+
+		expect(result.groupedPosts).toHaveLength(12);
+		for (let i = 0; i < result.groupedPosts.length - 1; i++) {
+			expect(result.groupedPosts[i].month).toBeGreaterThan(result.groupedPosts[i + 1].month);
+		}
+	});
+});

--- a/src/routes/sitemap.xml/server.spec.ts
+++ b/src/routes/sitemap.xml/server.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GET } from './+server';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+function makeRequest() {
+	return {} as Parameters<typeof GET>[0];
+}
+
+describe('GET /sitemap.xml', () => {
+	it('returns valid XML with the correct content-type header and includes static routes and post slugs', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			posts: { nodes: [{ slug: 'sunny-reading-june', date: '2025-06-01T09:00:00' }] }
+		});
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('application/xml');
+		const body = await response.text();
+		expect(body).toContain('<?xml version="1.0"');
+		expect(body).toContain('/about');
+		expect(body).toContain('/sunny-reading-june');
+		expect(body).toContain('2025-06-01');
+	});
+
+	it('returns a 500 response when fetchGraphQL throws', async () => {
+		vi.mocked(fetchGraphQL).mockRejectedValueOnce(new Error('GraphQL unavailable'));
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(500);
+	});
+});


### PR DESCRIPTION
## Summary

Adds 8 new unit tests across 4 previously untested areas, bringing the suite from 42 to 50 tests across 15 spec files.

### What's covered

- **`src/routes/gallery/page.spec.ts`** (3 tests) — the most complex untested file. Tests the cache-hit shortcut (verifies `fetchGraphQL` is never called), PXL filename filtering (and the indirect `getImageName` output via the `name` field), and descending month ordering for a full past year.
- **`src/lib/sanitize.spec.ts`** (1 test) — documents the intentional SSR passthrough where DOMPurify requires a DOM environment that isn't available server-side.
- **`src/routes/about/page.spec.ts`** (2 tests) — happy-path return of page data, and the 404 error thrown when `page` is `null`. (The identical `useful-links/+page.ts` follows the same pattern; the about tests serve as a representative case.)
- **`src/routes/sitemap.xml/server.spec.ts`** (2 tests) — valid XML generation with `application/xml` content-type, static route and post slug inclusion, correct `lastmod` date slicing; and the 500 fallback when GraphQL is unavailable.

### Why these were chosen

- Gallery load has 106 lines of business logic (parallel fetching, filtering, name parsing, caching, sorting) with zero prior test coverage — highest risk area.
- The sitemap and about/useful-links loaders are low-complexity but handle real error paths (`throw error(404, ...)`, `return new Response(..., { status: 500 })`) that are easy to regress.
- `sanitize.ts` has a silent server/client branch that was completely undocumented by tests.

https://claude.ai/code/session_0175D895peLnARFB1rg3NYc6

---
_Generated by [Claude Code](https://claude.ai/code/session_0175D895peLnARFB1rg3NYc6)_