### PR TITLE
perf(gallery): add intrinsic image dimensions and lazy-load to lightbox

### DIFF
--- a/src/lib/graphql/queries/getPostsForGallery.ts
+++ b/src/lib/graphql/queries/getPostsForGallery.ts
@@ -8,6 +8,10 @@ const GET_POSTS_FOR_GALLERY = `
         featuredImage {
           node {
             sourceUrl
+            mediaDetails {
+              width
+              height
+            }
           }
         }
       }

--- a/src/routes/gallery/+page.server.ts
+++ b/src/routes/gallery/+page.server.ts
@@ -6,18 +6,23 @@ import type { PageServerLoad } from './$types';
 const START_YEAR = 2020;
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+type MediaDetails = {
+	width?: number;
+	height?: number;
+};
+
 type GalleryPost = {
 	title: string;
 	slug: string;
 	date: string;
-	featuredImage?: { node?: { sourceUrl: string } };
+	featuredImage?: { node?: { sourceUrl: string; mediaDetails?: MediaDetails } };
 };
 
 type GalleryPostFiltered = {
 	title: string;
 	slug: string;
 	date: string;
-	featuredImage: { node: { sourceUrl: string } };
+	featuredImage: { node: { sourceUrl: string; mediaDetails?: MediaDetails } };
 };
 
 export type GalleryPostWithImage = GalleryPostFiltered & { name: string };

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -81,6 +81,8 @@
 									<img
 										src={post.featuredImage.node.sourceUrl}
 										alt={post.name}
+										width={post.featuredImage.node.mediaDetails?.width ?? undefined}
+										height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 										loading="lazy"
 									/>
 									<span class="photo-name" aria-hidden="true">{post.name}</span>
@@ -108,7 +110,7 @@
 			onkeydown={(e) => { if (e.key === 'Escape') closeLightbox(); }}
 		>
 			<button class="lightbox-close" onclick={closeLightbox} aria-label="Close lightbox">&#x2715;</button>
-			<img src={lightboxUrl} alt={lightboxName} />
+			<img src={lightboxUrl} alt={lightboxName} loading="lazy" />
 			{#if lightboxName}
 				<p class="lightbox-name">{lightboxName}</p>
 			{/if}


### PR DESCRIPTION
## Summary

Wednesday performance & SvelteKit optimisation pass. The gallery page had two image attribute gaps:

- **Gallery grid images lacked `width`/`height` attributes.** Browsers use these to compute an aspect-ratio hint before the image loads, so they can reserve the right amount of space in the layout. Without them the browser has to wait for the image response before it knows how tall the cell is — a source of Cumulative Layout Shift. The fix extends the `GET_POSTS_FOR_GALLERY` GraphQL query to request `mediaDetails { width height }` (the same field already used by `PostList.svelte`) and threads the new `MediaDetails` type through `GalleryPost` → `GalleryPostFiltered` → `GalleryPostWithImage` in the server load, then passes the values to the `<img>` elements in the template.

- **Lightbox `<img>` was missing `loading="lazy"`.** The lightbox element is only rendered after a user click so there's no CLS risk, but applying `loading="lazy"` is consistent with the rest of the site's image handling.

## Files changed

| File | Change |
|---|---|
| `src/lib/graphql/queries/getPostsForGallery.ts` | Add `mediaDetails { width height }` to query |
| `src/routes/gallery/+page.server.ts` | Add `MediaDetails` type; thread it through all three `GalleryPost*` types |
| `src/routes/gallery/+page.svelte` | Add `width`/`height` to grid `<img>`; add `loading="lazy"` to lightbox `<img>` |

## Test plan

- [ ] Visit `/gallery` and confirm photos render correctly in the grid
- [ ] Open a photo in the lightbox and confirm it displays as before
- [ ] In DevTools Network tab, filter to images — confirm gallery thumbnails show `loading: lazy` and that width/height attributes are present in the DOM
- [ ] Run Lighthouse on `/gallery` and check CLS score has not worsened (expect improvement or no change)
- [ ] `yarn svelte-check` passes with 0 errors (14 pre-existing warnings unchanged)

https://claude.ai/code/session_01N68eQBy6xsExFN5A56fxEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01N68eQBy6xsExFN5A56fxEf)_