### PR TITLE
fix(a11y/seo): accessibility and SEO improvements

### DIFF
--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -71,7 +71,7 @@ import { get } from 'svelte/store';
 		</ul>
 	{/if}
 
-	<button class="reply-button" onclick={() => toggleReplyForm(comment?.id)}>Reply</button>
+	<button class="reply-button" onclick={() => toggleReplyForm(comment?.id)} aria-label="Reply to {comment?.author.node.name}">Reply</button>
 
 	{#if $replyForms[comment?.id]}
 		<AddComment {postId} parentCommentId={comment.id} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -67,11 +67,11 @@
 		<form id="subscribe-form" onsubmit={handleSubmit}>
 			<label for="subscribe-name">
 				Name:
-				<input id="subscribe-name" autocomplete="name" type="text" bind:value={name} required />
+				<input id="subscribe-name" autocomplete="name" type="text" bind:value={name} required aria-required="true" />
 			</label>
 			<label for="subscribe-email">
 				Email:
-				<input id="subscribe-email" autocomplete="email" type="email" bind:value={email} required />
+				<input id="subscribe-email" autocomplete="email" type="email" bind:value={email} required aria-required="true" />
 			</label>
 			<button type="submit">Subscribe</button>
 		</form>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,14 @@
 	import '../styles/index.css';
 	import OnThisDay from '$lib/components/OnThisDay.svelte';
 	import PostList from '$lib/components/PostList.svelte';
+
+	const jsonLd = {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		name: 'Reading Weather',
+		description: data.meta.description,
+		url: 'https://www.readingweather.co.uk'
+	};
 </script>
 
 <svelte:head>
@@ -17,6 +25,7 @@
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/" />
+	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
 <h1>Weather Forecast For Reading & Berkshire</h1>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -11,10 +11,8 @@ import type { PageProps } from './$types';
 	<meta name="description" content={data.page.seo.description} />
 	<meta property="og:title" content={data.page.title} />
 	<meta property="og:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
-	{#if data.page.featuredImage?.node?.sourceUrl}
-		<meta property="og:image" content={data.page.featuredImage.node.sourceUrl} />
-	{/if}
-	<meta property="og:type" content="article" />
+	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
 </svelte:head>
 

--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -35,6 +35,7 @@
 	<meta name="description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
 	<meta property="og:title" content="Weather Forecast Archives – Reading Weather" />
 	<meta property="og:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
+	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/archives" />
 </svelte:head>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -49,6 +49,7 @@
 	<meta name="description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
 	<meta property="og:title" content="Photo Gallery – Reading Weather" />
 	<meta property="og:description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
+	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/gallery" />
 </svelte:head>

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -13,10 +13,8 @@ import type { PageProps } from './$types';
 	<meta name="description" content={data.page.seo.description} />
 	<meta property="og:title" content={data.page.title} />
 	<meta property="og:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
-	{#if data.page.featuredImage?.node?.sourceUrl}
-		<meta property="og:image" content={data.page.featuredImage.node.sourceUrl} />
-	{/if}
-	<meta property="og:type" content="article" />
+	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
 </svelte:head>
 

--- a/src/routes/seasonal-forecasts/+page.svelte
+++ b/src/routes/seasonal-forecasts/+page.svelte
@@ -8,14 +8,12 @@
 </script>
 
 <svelte:head>
-	<title>Seasonal Forecasts</title>
+	<title>Seasonal Forecasts – Reading Weather</title>
 	<meta name="description" content="Seasonal forecasts for Reading & Berkshire." />
-	<meta property="og:title" content="Seasonal Forecasts" />
+	<meta property="og:title" content="Seasonal Forecasts – Reading Weather" />
 	<meta property="og:description" content="Seasonal forecasts for Reading & Berkshire." />
-	{#if data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl}
-		<meta property="og:image" content={data.posts.posts.nodes[0].featuredImage.node.sourceUrl} />
-	{/if}
-	<meta property="og:type" content="article" />
+	<meta property="og:image" content={data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/seasonal-forecasts" />
 </svelte:head>
 

--- a/src/routes/useful-links/+page.svelte
+++ b/src/routes/useful-links/+page.svelte
@@ -17,10 +17,8 @@
 		property="og:description"
 		content={data.page.seo.opengraphDescription || data.page.seo.description}
 	/>
-	{#if data.page.featuredImage?.node?.sourceUrl}
-		<meta property="og:image" content={data.page.featuredImage.node.sourceUrl} />
-	{/if}
-	<meta property="og:type" content="article" />
+	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
 </svelte:head>
 


### PR DESCRIPTION
## Summary

Today's category: **Accessibility & SEO** (Thursday).

- **`aria-required` on subscribe form** — the layout footer form had `required` on its name/email inputs but was missing `aria-required="true"`, meaning screen readers wouldn't announce the fields as required
- **Unique Reply button labels** — when a post has multiple comments, all Reply buttons had the same accessible name ("Reply"). Each button now has `aria-label="Reply to <author name>"` so keyboard and screen reader users can distinguish them
- **WebSite JSON-LD on home page** — adds structured data (`@type: WebSite`) to help search engines better understand the site's identity
- **`og:image` fallback on 4 pages** — about, photographs, useful-links, and seasonal-forecasts conditionally rendered `og:image` only when a featured image existed, leaving social card previews blank if none was set; all now fall back to the default `weather.png`
- **`og:image` added to gallery and archives** — these two pages had no `og:image` at all
- **`og:type` corrected on 4 pages** — about, photographs, useful-links, and seasonal-forecasts were tagged `og:type="article"`, which is incorrect for non-blog-post pages; changed to `"website"`
- **Seasonal forecasts page title** — was "Seasonal Forecasts" (no site name); now "Seasonal Forecasts – Reading Weather", consistent with all other pages

## Test plan

- [ ] Verify subscribe form: inspect the name and email inputs and confirm `aria-required="true"` is present on both
- [ ] Visit a post with multiple comments and confirm each Reply button has a distinct label (`aria-label="Reply to X"`) in the DOM
- [ ] Check home page source for `application/ld+json` WebSite schema
- [ ] Share an about/photographs/useful-links/seasonal-forecasts URL in a social preview tool (e.g. opengraph.xyz) and confirm the image renders
- [ ] Check gallery and archives social previews similarly
- [ ] Confirm seasonal-forecasts `<title>` tag now reads "Seasonal Forecasts – Reading Weather"

https://claude.ai/code/session_01FWwytMYY2aNdLjeN5teqYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWwytMYY2aNdLjeN5teqYJ)_