### PR TITLE
test: add unit tests for seasonal-forecasts, useful-links, and sitemap-2.xml

### DIFF
--- a/src/routes/seasonal-forecasts/page.spec.ts
+++ b/src/routes/seasonal-forecasts/page.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SeasonalPostsResponse } from '$lib/types';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+const mockPost = {
+	date: '2025-06-01T00:00:00',
+	slug: 'summer-2025-forecast',
+	title: 'Summer 2025 Forecast',
+	content: '<p>Warm and sunny</p>',
+	featuredImage: { node: { sourceUrl: '/img/summer.jpg', srcSet: '' } },
+	comments: { nodes: [] }
+};
+
+describe('seasonal-forecasts page load', () => {
+	it('returns the full GraphQL response in the posts key', async () => {
+		const mockResponse: SeasonalPostsResponse = { posts: { nodes: [mockPost] } };
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce(mockResponse);
+
+		const result = await load({} as Parameters<typeof load>[0]);
+
+		expect(result.posts).toEqual(mockResponse);
+	});
+
+	it('propagates errors thrown by fetchGraphQL', async () => {
+		vi.mocked(fetchGraphQL).mockRejectedValueOnce(new Error('Network error'));
+
+		await expect(load({} as Parameters<typeof load>[0])).rejects.toThrow('Network error');
+	});
+});

--- a/src/routes/sitemap-2.xml/server.spec.ts
+++ b/src/routes/sitemap-2.xml/server.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GET } from './+server';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+function makeRequest() {
+	return {} as Parameters<typeof GET>[0];
+}
+
+describe('GET /sitemap-2.xml', () => {
+	it('returns valid XML with correct headers, static routes, and post slugs', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			posts: { nodes: [{ slug: 'reading-frost-2025', date: '2025-01-10T08:00:00' }] }
+		});
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('application/xml');
+		expect(response.headers.get('Cache-Control')).toBe('max-age=0, s-maxage=3600');
+		const body = await response.text();
+		expect(body).toContain('<?xml version="1.0"');
+		expect(body).toContain('/about');
+		expect(body).toContain('/reading-frost-2025');
+		expect(body).toContain('2025-01-10');
+	});
+
+	it('escapes XML special characters in post slugs', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			posts: { nodes: [{ slug: 'rain-&-shine', date: null }] }
+		});
+
+		const response = await GET(makeRequest());
+		const body = await response.text();
+
+		expect(body).toContain('rain-&amp;-shine');
+		expect(body).not.toContain('rain-&-shine');
+	});
+
+	it('returns a 500 response when fetchGraphQL throws', async () => {
+		vi.mocked(fetchGraphQL).mockRejectedValueOnce(new Error('GraphQL unavailable'));
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(500);
+	});
+});

--- a/src/routes/useful-links/page.spec.ts
+++ b/src/routes/useful-links/page.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GqlPageNode } from '$lib/types';
+import { load } from './+page';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+const mockPage: GqlPageNode = {
+	title: 'Useful Links',
+	slug: 'useful-links',
+	content: '<p>Links to useful weather resources.</p>',
+	seo: { description: 'Useful weather links', opengraphDescription: 'Useful links OG' }
+};
+
+describe('useful-links page load', () => {
+	it('returns the page when fetchGraphQL resolves a page', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ page: mockPage });
+
+		const result = await load({} as Parameters<typeof load>[0]);
+
+		expect(result).toEqual({ page: mockPage });
+	});
+
+	it('throws a 404 error when fetchGraphQL returns no page', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ page: null });
+
+		await expect(load({} as Parameters<typeof load>[0])).rejects.toMatchObject({ status: 404 });
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `page.spec.ts` for the **seasonal-forecasts** route: verifies the `load` function returns the full GraphQL response under the `posts` key, and that network errors propagate correctly.
- Adds `page.spec.ts` for the **useful-links** route: follows the same pattern as `about` and `photographs` — returns the page on success and throws a 404 when GraphQL resolves `null`.
- Adds `server.spec.ts` for the **sitemap-2.xml** endpoint: verifies valid XML output with correct `Content-Type` and `Cache-Control` headers, that XML special characters in slugs are properly escaped, and that a GraphQL failure returns a 500 response.

These were the three route handlers with zero test coverage. All 57 unit tests pass after this change (50 pre-existing + 7 new).

## Test plan

- [x] `yarn test:unit --run` → 18 test files, 57 tests, all green
- [x] No changes to production code

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYRuNSaFVF3YuzWTGgX2aL)_