### PR TITLE
feat: add latest seasonal forecast link to post pages (#312)

### DIFF
--- a/src/lib/graphql/queries/getLatestSeasonalPost.ts
+++ b/src/lib/graphql/queries/getLatestSeasonalPost.ts
@@ -1,0 +1,23 @@
+const GET_LATEST_SEASONAL_POST_QUERY = `
+  query GetLatestSeasonalPost {
+    posts(first: 1, where: { categoryName: "seasonal" }) {
+      nodes {
+        slug
+        title
+        date
+        featuredImage {
+          node {
+            sourceUrl(size: MEDIUM_LARGE)
+            srcSet(size: MEDIUM_LARGE)
+            mediaDetails {
+              width
+              height
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default GET_LATEST_SEASONAL_POST_QUERY;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,23 @@ export type SeasonalPostsResponse = {
 	};
 };
 
+export type LatestSeasonalPostResponse = {
+	posts: {
+		nodes: Array<{
+			slug: string;
+			title: string;
+			date: string;
+			featuredImage?: {
+				node?: {
+					sourceUrl: string;
+					srcSet: string;
+					mediaDetails?: { width?: number; height?: number };
+				};
+			};
+		}>;
+	};
+};
+
 export type OnThisDayResponse = {
 	posts: {
 		nodes: Array<{

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,9 +1,10 @@
 import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_LATEST_POST_SLUG from '$lib/graphql/queries/getLatestPostSlug';
+import GET_LATEST_SEASONAL_POST_QUERY from '$lib/graphql/queries/getLatestSeasonalPost';
 import GET_POST_BY_SLUG from '$lib/graphql/queries/getPostBySlug';
 import { getCache, setCache } from '$lib/server/cache';
-import type { GetLatestPostSlugResponse, GetPostBySlugResponse } from '$lib/types';
+import type { GetLatestPostSlugResponse, GetPostBySlugResponse, LatestSeasonalPostResponse } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 const LATEST_SLUG_CACHE_KEY = 'latest-post-slug';
@@ -22,9 +23,10 @@ async function fetchLatestPostSlug(): Promise<string | undefined> {
 export const load: PageServerLoad = async ({ params }) => {
 	const { slug } = params;
 
-	const [response, latestSlug] = await Promise.all([
+	const [response, latestSlug, latestSeasonal] = await Promise.all([
 		fetchGraphQL<GetPostBySlugResponse>(GET_POST_BY_SLUG, { slug }),
-		fetchLatestPostSlug()
+		fetchLatestPostSlug(),
+		fetchGraphQL<LatestSeasonalPostResponse>(GET_LATEST_SEASONAL_POST_QUERY)
 	]);
 
 	if (!response.postBy) {
@@ -34,6 +36,7 @@ export const load: PageServerLoad = async ({ params }) => {
 	return {
 		post: response.postBy,
 		isLatest: latestSlug === slug,
-		latestSlug
+		latestSlug,
+		latestSeasonalPost: latestSeasonal?.posts?.nodes?.[0] ?? null
 	};
 };

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -139,3 +139,10 @@
 		<AddComment {postId} />
 	{/if}
 </article>
+
+{#if data.latestSeasonalPost}
+	<section class="latest-seasonal">
+		<h2>Latest Seasonal Forecast</h2>
+		<a href="/{data.latestSeasonalPost.slug}">{data.latestSeasonalPost.title}</a>
+	</section>
+{/if}

--- a/src/routes/[slug]/page.spec.ts
+++ b/src/routes/[slug]/page.spec.ts
@@ -66,12 +66,14 @@ describe('[slug] page load', () => {
 
 	it('uses cached latest slug when available', async () => {
 		vi.mocked(getCache).mockReturnValue('cached-latest-slug');
-		vi.mocked(fetchGraphQL).mockResolvedValueOnce({ postBy: mockPost });
+		vi.mocked(fetchGraphQL)
+			.mockResolvedValueOnce({ postBy: mockPost })
+			.mockResolvedValueOnce({ posts: { nodes: [] } });
 
 		const result = (await load({ params: { slug: 'test-post' } } as Parameters<typeof load>[0])) as SlugLoadResult;
 
 		expect(result.isLatest).toBe(false);
 		expect(result.latestSlug).toBe('cached-latest-slug');
-		expect(vi.mocked(fetchGraphQL)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(fetchGraphQL)).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -99,6 +99,22 @@ main {
 	}
 }
 
+.latest-seasonal {
+	border: 5px solid var(--nav);
+	margin-bottom: 2rem;
+	padding: 1rem;
+	text-align: center;
+	background: var(--white);
+
+	h2 {
+		margin: 0 0 0.75rem;
+	}
+
+	a {
+		font-size: 1.125rem;
+	}
+}
+
 .older-posts {
 	text-align: center;
 	margin: 0 0 2rem 0;


### PR DESCRIPTION
## Summary

- Post pages were dead ends with no onward navigation after reading a forecast
- Each post page now fetches the most recent seasonal forecast in parallel with existing data
- A "Latest Seasonal Forecast" section with a link is rendered at the bottom of every post, below the comments

## Test plan

- [ ] Visit any forecast post (e.g. `/some-post-slug`) and confirm a "Latest Seasonal Forecast" section appears below the comments
- [ ] Confirm the link navigates to the correct seasonal forecast post
- [ ] Confirm the section has a white background and the nav-colour border
- [ ] Confirm the homepage is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)