### PR TITLE
perf: use SvelteKit goto() for gallery/archive navigation; fix lightbox lazy-load

### DIFF
--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../../styles/index.css';
+	import { goto } from '$app/navigation';
 	import type { PageProps } from './$types';
 
 	const { data }: PageProps = $props();
@@ -8,7 +9,7 @@
 		const selected = event.currentTarget.value;
 		if (!selected) return;
 		const [year, month] = selected.split('-');
-		window.location.href = `archives/?year=${year}&month=${month}`;
+		goto(`/archives?year=${year}&month=${month}`);
 	};
 
 	const getMonthName = (month: number): string => {

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../../styles/index.css';
+	import { goto } from '$app/navigation';
 	import type { PageProps } from './$types';
 
 	const { data }: PageProps = $props();
@@ -12,7 +13,7 @@
 	const updateYear = (event: Event & { currentTarget: EventTarget & HTMLSelectElement }): void => {
 		const selected = event.currentTarget.value;
 		if (!selected) return;
-		window.location.href = `gallery?year=${selected}`;
+		goto(`/gallery?year=${selected}`);
 	};
 
 	let lightboxUrl = $state('');
@@ -111,7 +112,7 @@
 			onkeydown={(e) => { if (e.key === 'Escape') closeLightbox(); }}
 		>
 			<button class="lightbox-close" onclick={closeLightbox} aria-label="Close lightbox">&#x2715;</button>
-			<img src={lightboxUrl} alt={lightboxName} loading="lazy" />
+			<img src={lightboxUrl} alt={lightboxName} loading="eager" />
 			{#if lightboxName}
 				<p class="lightbox-name">{lightboxName}</p>
 			{/if}


### PR DESCRIPTION
## Summary

- **Gallery & Archives year/month selectors**: replaced `window.location.href` with SvelteKit's `goto()` from `$app/navigation`. Previously each dropdown selection triggered a full page reload (new HTTP request, full re-render, layout remount). With `goto()`, SvelteKit's client-side router handles the navigation — it re-runs only the affected load function and reuses the existing app shell, making filter changes noticeably faster.
- **Lightbox image**: changed `loading="lazy"` to `loading="eager"`. The lightbox `<img>` is conditionally rendered inside `{#if lightboxUrl}`, meaning it's only added to the DOM when the user actually opens the lightbox. At that moment the user is actively waiting to see the image, so deferring the load is the wrong behaviour — `eager` loads it as soon as it's mounted.

## Files changed

- `src/routes/gallery/+page.svelte`
- `src/routes/archives/+page.svelte`

## Test plan

- [ ] Open the Gallery page, change the year dropdown — confirm it navigates without a full page reload (layout stays mounted, URL updates in-place)
- [ ] Open the Archives page, change the month/year dropdown — same check
- [ ] Open the Gallery, click a photo to open the lightbox — confirm the full-size image loads immediately without delay

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3xJbRZksK5mShtFvmWGgn)_