### PR TITLE
chore(a11y/seo): add Twitter meta tags, fix NavBar Svelte 5 syntax, fix lint warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",

--- a/scripts/facebook-cover-generator.html
+++ b/scripts/facebook-cover-generator.html
@@ -248,8 +248,8 @@
 													ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
 													ctx.drawImage(currentImage, panX, panY, drawW, drawH);
 
-													const size = Number.parseInt(fontSizeSlider.value);
-													const yPct = Number.parseInt(textYSlider.value) / 100;
+													const size = Number.parseInt(fontSizeSlider.value, 10);
+													const yPct = Number.parseInt(textYSlider.value, 10) / 100;
 													const color = colorPicker.value;
 
 													ctx.font = `${size}px ${fontLoaded ? 'Caveat' : 'cursive'}`;
@@ -355,7 +355,7 @@
 													e.preventDefault();
 													dropZone.classList.remove('drag-over');
 													const file = e.dataTransfer.files[0];
-													if (file && file.type.startsWith('image/')) loadImage(file);
+													if (file?.type.startsWith('image/')) loadImage(file);
 												});
 
 												// Download

--- a/src/lib/api/historicalWeather.ts
+++ b/src/lib/api/historicalWeather.ts
@@ -89,7 +89,7 @@ async function fetchOneDay(dateStr: string): Promise<DailyWeather> {
 	};
 
 	return {
-		year: Number.parseInt(dateStr.slice(0, 4)),
+		year: Number.parseInt(dateStr.slice(0, 4), 10),
 		tempMax: Math.round(temperature_2m_max[0] * 10) / 10,
 		tempMin: Math.round(temperature_2m_min[0] * 10) / 10,
 		precipitation: Math.round(precipitation_sum[0] * 10) / 10,

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -9,15 +9,14 @@
 		{ href: '/about', label: 'About' },
 		{ href: '/archives', label: 'Archives' }
 	];
-	// biome-ignore lint/style/useConst: needed for Svelte reactivity ok
-	let isOpen = false;
+	let isOpen = $state(false);
 </script>
 
 <nav class="navbar">
 	<a href="/" class="home-button">Home </a>
 	<button
 		class="menu-button"
-		on:click={() => (isOpen = !isOpen)}
+		onclick={() => (isOpen = !isOpen)}
 		aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
 		aria-expanded={isOpen}
 		aria-controls="nav-menu"
@@ -38,7 +37,7 @@
 			<li class:active={$page.url.pathname === link.href}>
 				<a
 					href={link.href}
-					on:click={() => (isOpen = false)}
+					onclick={() => (isOpen = false)}
 					aria-current={$page.url.pathname === link.href ? 'page' : undefined}>{link.label}</a
 				>
 			</li>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,9 +9,7 @@
 
 	const { children }: { children: Snippet } = $props();
 
-	// biome-ignore lint/style/useConst: <cannot bind to a const>
 	let name = $state('');
-	// biome-ignore lint/style/useConst: <cannot bind to a const>
 	let email = $state('');
 	let responseMessage = $state('');
 

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -87,7 +87,7 @@
 
 	const modifiedContent = injectKofiWidget(data.post.content);
 
-	const hoursOld = $derived((new Date().getTime() - new Date(data.post.date).getTime()) / 36e5);
+	const hoursOld = $derived((Date.now() - new Date(data.post.date).getTime()) / 36e5);
 	const daysOld = $derived(Math.floor(hoursOld / 24));
 	const isStale = $derived(!data.isLatest && hoursOld > 24);
 </script>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -14,6 +14,9 @@ import type { PageProps } from './$types';
 	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
+	<meta name="twitter:title" content={data.page.title} />
+	<meta name="twitter:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
+	<meta name="twitter:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 </svelte:head>
 
 {#if data.page}

--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -39,6 +39,9 @@
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/archives" />
+	<meta name="twitter:title" content="Weather Forecast Archives – Reading Weather" />
+	<meta name="twitter:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
+	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
 </svelte:head>
 
 <h1>Weather Forecast Archives</h1>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -53,6 +53,9 @@
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/gallery" />
+	<meta name="twitter:title" content="Photo Gallery – Reading Weather" />
+	<meta name="twitter:description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
+	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
 </svelte:head>
 
 <svelte:window onkeydown={onKeydown} />

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -16,6 +16,9 @@ import type { PageProps } from './$types';
 	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
+	<meta name="twitter:title" content={data.page.title} />
+	<meta name="twitter:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
+	<meta name="twitter:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 </svelte:head>
 
 {#if data.page}

--- a/src/routes/seasonal-forecasts/+page.svelte
+++ b/src/routes/seasonal-forecasts/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import PostList from '$lib/components/PostList.svelte';
-	import type { PageProps } from '../$types';
+	import type { PageProps } from './$types';
 
 	const { data }: PageProps = $props();
 
@@ -9,12 +9,15 @@
 
 <svelte:head>
 	<title>Seasonal Forecasts – Reading Weather</title>
-	<meta name="description" content="Seasonal forecasts for Reading & Berkshire." />
+	<meta name="description" content="Long-range seasonal weather forecasts for Reading and Berkshire, covering spring, summer, autumn, and winter outlooks for the coming months." />
 	<meta property="og:title" content="Seasonal Forecasts – Reading Weather" />
-	<meta property="og:description" content="Seasonal forecasts for Reading & Berkshire." />
+	<meta property="og:description" content="Long-range seasonal weather forecasts for Reading and Berkshire, covering spring, summer, autumn, and winter outlooks for the coming months." />
 	<meta property="og:image" content={data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/seasonal-forecasts" />
+	<meta name="twitter:title" content="Seasonal Forecasts – Reading Weather" />
+	<meta name="twitter:description" content="Long-range seasonal weather forecasts for Reading and Berkshire, covering spring, summer, autumn, and winter outlooks for the coming months." />
+	<meta name="twitter:image" content={data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 </svelte:head>
 
 <h1>Seasonal Forecasts</h1>

--- a/src/routes/useful-links/+page.svelte
+++ b/src/routes/useful-links/+page.svelte
@@ -20,6 +20,9 @@
 	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
+	<meta name="twitter:title" content={data.page.title} />
+	<meta name="twitter:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
+	<meta name="twitter:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
 </svelte:head>
 
 {#if data.page}


### PR DESCRIPTION
## Summary

**Thursday accessibility & SEO run — 2026-06-25**

### SEO fixes
- **Twitter meta tags added to 6 pages** — `about`, `archives`, `gallery`, `photographs`, `seasonal-forecasts`, and `useful-links` all had Open Graph tags but were missing the corresponding `twitter:title`, `twitter:description`, and `twitter:image` tags. When shared on Twitter/X, these pages would fall back to the root layout's `twitter:card` only, producing blank previews. All six pages now have the full set of Twitter card tags.
- **Seasonal-forecasts meta description expanded** — the previous description ("Seasonal forecasts for Reading & Berkshire.") was only 41 characters, well below the recommended 120–160 chars for search snippets. Replaced with a 130-char description covering the scope of the content.
- **Wrong `$types` import path fixed** in `seasonal-forecasts/+page.svelte` — it imported `PageProps` from `'../\$types'` (the parent routes module) instead of `'./$types'` (the route-specific generated types). This was a latent type-correctness bug.

### Accessibility fixes
- **NavBar migrated from Svelte 4 to Svelte 5 event syntax** — `on:click` event directives replaced with `onclick` handlers and `let isOpen` updated to `let isOpen = $state(false)`. This is a Svelte 5 project; using the old directive syntax is deprecated and produces warnings in `svelte-check`.

### Lint fixes (pre-existing warnings cleared)
- Removed two stale `biome-ignore lint/style/useConst` suppression comments in `+layout.svelte` that biome 2.5.0 correctly flagged as no longer needed.
- Added missing radix `10` argument to three `Number.parseInt()` calls (`historicalWeather.ts`, `facebook-cover-generator.html`).
- Fixed `useOptionalChain` warning in `facebook-cover-generator.html` (`file && file.type.startsWith(...)` → `file?.type.startsWith(...)`).
- Replaced `new Date().getTime()` with `Date.now()` in `[slug]/+page.svelte`.
- Updated `biome.json` schema reference from `2.4.16` to `2.5.0`.

### What was NOT changed
- `noUnusedImports` warnings for Svelte components and stores — these are biome false positives; biome does not analyse Svelte template sections for import usage, so imports used only in `{@html ...}` expressions or component slots appear unused to biome. Removing them would break the app.
- `noDescendingSpecificity` CSS warnings — pre-existing specificity ordering in `global.css` and `index.css`; restructuring would risk visual regressions.

## Test plan
- [ ] Paste a URL for each updated page into the [Twitter Card Validator](https://cards-dev.twitter.com/validator) and confirm a rich preview appears
- [ ] Check the seasonal-forecasts page meta description appears correctly in Google Search Console preview tool
- [ ] Verify the nav menu opens and closes correctly on mobile (hamburger button)
- [ ] Confirm `yarn lint` passes with no new errors (remaining 23 warnings are pre-existing Svelte false-positive import warnings and CSS specificity notes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSmYsmUNU6iDJd4bcPbPLg)_