### PR TITLE
chore(typescript): add explicit generic to getCache and fix biome config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -25,7 +25,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noParameterAssign": "error",
 				"useAsConstAssertion": "error",
@@ -47,5 +47,17 @@
 		"formatter": {
 			"quoteStyle": "double"
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["**/*.svelte"],
+			"linter": {
+				"rules": {
+					"correctness": {
+						"noUnusedImports": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/src/routes/api/historical-weather/+server.ts
+++ b/src/routes/api/historical-weather/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit';
-import { fetchHistoricalWeather } from '$lib/api/historicalWeather';
+import { type DailyWeather, fetchHistoricalWeather } from '$lib/api/historicalWeather';
 import { getCache, setCache } from '$lib/server/cache';
 import type { RequestHandler } from './$types';
 
@@ -14,7 +14,7 @@ export const GET: RequestHandler = async ({ url }) => {
 	}
 
 	const cacheKey = `historical-weather-${month}-${day}`;
-	const cached = getCache(cacheKey);
+	const cached = getCache<DailyWeather[]>(cacheKey);
 	if (cached) return json(cached);
 
 	const data = await fetchHistoricalWeather(month, day);


### PR DESCRIPTION
## Summary

- **`getCache<DailyWeather[]>` in `historical-weather/+server.ts`** — the one production call-site missing an explicit type parameter. Every other `getCache` call in the codebase already specifies the type (`getCache<string>`, `getCache<SitemapNode[]>`, `getCache<GroupedMonth[]>`); this brings the historical-weather handler into line.
- **`biome.json` schema version** — bumped from `2.5.0` to `2.5.1` to match the installed biome version; applied via `biome migrate --write`.
- **Deprecated `recommended: true`** — replaced with `preset: "recommended"` as required by biome 2.5.x.
- **Svelte `noUnusedImports` override** — biome cannot analyse Svelte template syntax, so imports used only in templates (components, `{@html fn(...)}` calls, `$store` references) were all falsely reported as unused. Added an `overrides` entry to disable `noUnusedImports` for `*.svelte` files, eliminating ~20 false-positive warnings and making `yarn lint` output meaningful again.

## What was checked

- Searched the whole codebase for `any` usage — none found.
- Audited all `interface` declarations — the only one (`interface Window` in `app.d.ts`) correctly uses declaration merging and should remain an `interface`.
- Reviewed all `getCache` call-sites; only the historical-weather handler lacked an explicit type parameter.
- All other production TypeScript (route load functions, API handlers, components) is already well-typed with `strict: true`.

## Test plan

- [ ] `yarn lint` exits 0 (only 3 pre-existing CSS specificity warnings remain, all at warning severity)
- [ ] The historical-weather endpoint still compiles; TypeScript now infers the cached value as `DailyWeather[]` instead of `unknown`
- [ ] No Svelte component imports are removed — the biome override suppresses false positives, not real unused imports

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBTY1AeFnwdRJN5mTvzw4Q)_