### PR TITLE
test: add missing coverage for security headers, cache, and GraphQL edge cases

### DIFF
--- a/src/hooks.server.spec.ts
+++ b/src/hooks.server.spec.ts
@@ -71,4 +71,59 @@ describe('hooks handle', () => {
 
 		expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
 	});
+
+	it('sets Referrer-Policy: strict-origin-when-cross-origin on all responses', async () => {
+		const response = await handle({
+			event: makeEvent('/any-page') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+	});
+
+	it('sets a Permissions-Policy header that blocks camera, microphone, and geolocation', async () => {
+		const response = await handle({
+			event: makeEvent('/any-page') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		const policy = response.headers.get('Permissions-Policy') ?? '';
+		expect(policy).toContain('camera=()');
+		expect(policy).toContain('microphone=()');
+		expect(policy).toContain('geolocation=()');
+	});
+
+	it('sets a Content-Security-Policy header with key directives', async () => {
+		const response = await handle({
+			event: makeEvent('/any-page') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		const csp = response.headers.get('Content-Security-Policy') ?? '';
+		expect(csp).toContain("default-src 'self'");
+		expect(csp).toContain("object-src 'none'");
+		expect(csp).toContain('https://www.googletagmanager.com');
+	});
+
+	it('does not set slug cache-control for paths that start with /api', async () => {
+		const response = await handle({
+			event: makeEvent('/api') as Parameters<typeof handle>[0]['event'],
+			resolve: makeResolve()
+		});
+
+		expect(response.headers.get('cache-control')).toBeNull();
+	});
+
+	it('preserves an existing cache-control header set by the load function', async () => {
+		const resolve = vi.fn().mockResolvedValue(
+			new Response('ok', { headers: { 'cache-control': 'public, max-age=3600' } })
+		);
+
+		const response = await handle({
+			event: makeEvent('/gallery') as Parameters<typeof handle>[0]['event'],
+			resolve
+		});
+
+		expect(response.headers.get('cache-control')).toBe('public, max-age=3600');
+	});
 });

--- a/src/lib/graphql/api.spec.ts
+++ b/src/lib/graphql/api.spec.ts
@@ -100,4 +100,41 @@ describe('addComment', () => {
 
 		expect(result).toEqual({ success: false });
 	});
+
+	it('includes parentId in the mutation input variables when provided', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			headers: jsonHeaders,
+			json: async () => ({ data: { createComment: { success: true } } })
+		});
+		vi.stubGlobal('fetch', mockFetch);
+
+		await addComment(123, 'Reply!', 'Alice', 'alice@example.com', 456);
+
+		const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+		const body = JSON.parse(options.body) as { variables: { input: { parent: number } } };
+		expect(body.variables.input.parent).toBe(456);
+	});
+});
+
+describe('fetchGraphQL — non-JSON response', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('throws with a descriptive message when the endpoint returns a non-JSON content-type', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				headers: { get: (key: string) => (key === 'content-type' ? 'text/html' : null) },
+				json: async () => ({})
+			})
+		);
+
+		await expect(fetchGraphQL('{ posts { nodes { id } } }')).rejects.toThrow(
+			'GraphQL endpoint returned non-JSON response (200)'
+		);
+	});
 });


### PR DESCRIPTION
## Summary

- **`hooks.server.spec.ts`** — adds 5 tests for previously uncovered security header and cache-control behaviours
- **`graphql/api.spec.ts`** — adds 2 tests for uncovered `fetchGraphQL` and `addComment` edge cases

### New hooks.server tests

| Test | What it guards |
|---|---|
| `Referrer-Policy: strict-origin-when-cross-origin` is set | Regression if the header is accidentally removed |
| `Permissions-Policy` blocks camera, microphone, geolocation | Regression if the policy string changes |
| CSP contains `default-src 'self'`, `object-src 'none'`, GTM origin | Most security-critical header; no test existed |
| `/api` single-segment path is excluded from slug cache-control | The `!pathname.startsWith('/api')` guard was untested |
| Existing `cache-control` set by a load function is preserved | Ensures gallery (and future routes) that set their own header aren't overridden |

### New GraphQL API tests

| Test | What it guards |
|---|---|
| `fetchGraphQL` throws with status code when endpoint returns non-JSON | The content-type check branch was never exercised |
| `addComment` forwards `parentId` in the mutation `input` | Reply-to-comment path was untested; only the `null` default was implicitly covered |

## Test plan

- All 91 tests pass (`84` pre-existing + `7` new): `npx vitest --run`
- `yarn lint` reports no errors (3 pre-existing CSS warnings in `global.css`, unrelated to this PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmjxNSQeRfyiabhAWUDZ8e)_