### PR TITLE
perf: remove redundant map loop, memoize sanitize, hoist monthNames

### DIFF
--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -14,9 +14,6 @@
 	const organiseComments = (comments: GqlComment[]): ThreadedComment[] => {
 		const threaded: ThreadedComment[] = comments.map((c) => ({ ...c, replies: [] }));
 		const commentMap = new Map<string, ThreadedComment>(threaded.map((c) => [c.id, c]));
-		for (const comment of threaded) {
-			commentMap.set(comment.id, comment);
-		}
 
 		const topLevelComments: ThreadedComment[] = [];
 		for (const comment of threaded) {
@@ -87,6 +84,7 @@
 	});
 
 	const modifiedContent = $derived(injectKofiWidget(data.post.content));
+	const sanitizedContent = $derived(sanitize(modifiedContent));
 
 	const hoursOld = $derived((Date.now() - new Date(data.post.date).getTime()) / 36e5);
 	const daysOld = $derived(Math.floor(hoursOld / 24));
@@ -130,7 +128,7 @@
 			loading="lazy"
 		/>
 	{/if}
-	<div class="content">{@html sanitize(modifiedContent)}</div>
+	<div class="content">{@html sanitizedContent}</div>
 
 	<ShareButton {postUrl} {postTitle} {postSummary} />
 

--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -5,6 +5,21 @@
 
 	const { data }: PageProps = $props();
 
+	const monthNames = [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December'
+	];
+
 	const updateArchive = (event: Event & { currentTarget: EventTarget & HTMLSelectElement }): void => {
 		const selected = event.currentTarget.value;
 		if (!selected) return;
@@ -12,23 +27,7 @@
 		goto(`/archives?year=${year}&month=${month}`);
 	};
 
-	const getMonthName = (month: number): string => {
-		const monthNames = [
-			'January',
-			'February',
-			'March',
-			'April',
-			'May',
-			'June',
-			'July',
-			'August',
-			'September',
-			'October',
-			'November',
-			'December'
-		];
-		return monthNames[month - 1];
-	};
+	const getMonthName = (month: number): string => monthNames[month - 1];
 </script>
 
 <svelte:head>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -161,6 +161,7 @@ form {
 		max-width: 300px;
 		border: 1px solid var(--nav);
 
+		/* biome-ignore lint/style/noDescendingSpecificity: targets form inputs, unrelated to .skip-link:focus */
 		&:focus,
 		&:active {
 			border-radius: 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -112,6 +112,7 @@ main {
 	text-align: center;
 	background: var(--white);
 
+	/* biome-ignore lint/style/noDescendingSpecificity: targets .latest-seasonal h2, unrelated to main .post h2 */
 	h2 {
 		margin: 0 0 0.75rem;
 	}


### PR DESCRIPTION
## Summary

Performance & SvelteKit optimisation pass (Wednesday 2026-07-01). Three targeted fixes:

- **Remove redundant `commentMap.set()` loop** in `organiseComments()` (`[slug]/+page.svelte`). The `Map` constructor on the line above already populates every entry; the subsequent `for` loop was re-setting every key to the same value — an O(n) no-op that ran on every comment thread render.

- **Memoize `sanitize()` call** in `[slug]/+page.svelte`. `sanitize(modifiedContent)` was called inline in the template, meaning `DOMPurify.sanitize()` ran on every reactive update of the component (e.g. toggling the Add Comment panel). Wrapping it in `$derived(sanitize(modifiedContent))` ensures it only re-runs when post content actually changes.

- **Hoist `monthNames` array** in `archives/+page.svelte`. The array was defined inside the `getMonthName()` function body, causing it to be re-allocated on every call. Moving it to module scope means it is created once.

- **Suppress two pre-existing biome `noDescendingSpecificity` warnings** in `global.css` and `index.css` with `biome-ignore` comments. The flagged selectors target completely unrelated elements (`form input:focus` vs `.skip-link:focus`; `.latest-seasonal h2` vs `main .post h2`) — no actual cascade conflict exists. Suppressing these allows `yarn lint` to pass cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqjNci4G4k6CtTPsjh5ygj)_