### PR TITLE
Move NavBar transition timing out of inline style

### DIFF
--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -28,11 +28,7 @@
 		</svg>
 	</button>
 
-	<ul
-		id="nav-menu"
-		class:open={isOpen}
-		style="transition: {isOpen ? 'max-height 0.3s ease-out, visibility 0s 0s' : 'max-height 0.3s ease-out, visibility 0s 0.3s'};"
-	>
+	<ul id="nav-menu" class:open={isOpen}>
 		{#each links as link}
 			<li class:active={$page.url.pathname === link.href}>
 				<a
@@ -93,6 +89,9 @@
 		overflow: hidden;
 		padding: 0 1rem;
 		margin-top: 0.75rem;
+		transition:
+			max-height 0.3s ease-out,
+			visibility 0s 0.3s;
 
 		@media screen and (min-width: 768px) {
 			margin-top: 0;
@@ -101,6 +100,9 @@
 
 	.navbar ul.open {
 		max-height: 500px;
+		transition:
+			max-height 0.3s ease-out,
+			visibility 0s 0s;
 	}
 
 	.navbar li a {


### PR DESCRIPTION
## Category
Bad patterns

## Issue
`NavBar.svelte` computed the mobile nav menu's `visibility` transition-delay in an inline `style=` attribute, branching on `isOpen`, even though this project uses scoped CSS classes for styling (`class:open={isOpen}` was already applied to the same element).

## Change
Removed the inline `style` attribute and moved the two transition states into the existing `.navbar ul` / `.navbar ul.open` scoped CSS rules, so the closed state transitions with a `0.3s` visibility delay and the open state transitions immediately, matching the prior behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_017kQL48MvyGiYkfsB3HZbKG)_