### PR TITLE
feat: add Weekly Digest homepage card

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,14 @@
       "Bash(yarn test *)",
       "Bash(yarn lint *)",
       "Bash(yarn biome *)",
-      "Bash(git diff *)"
+      "Bash(git diff *)",
+      "Bash(yarn test:unit run)",
+      "Bash(cp /tmp/shot.js ./shot.tmp.cjs)",
+      "Bash(node ./shot.tmp.cjs)",
+      "Bash(rm ./shot.tmp.cjs)",
+      "Bash(rm -f /c/tmp/homepage.png /tmp/home.html /tmp/dev.log /tmp/shot.js)",
+      "Bash(netstat -ano)",
+      "Bash(taskkill //F //IM node.exe)"
     ]
   }
 }

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -68,4 +68,10 @@ describe('fetchWeeklyDigest', () => {
 			'Open-Meteo error: 500'
 		);
 	});
+
+	it('passes an abort signal so a slow upstream response fails fast', async () => {
+		await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+		expect(options.signal).toBeInstanceOf(AbortSignal);
+	});
 });

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWeeklyDigest } from './weeklyDigest';
 
-function makeArchiveResponse(hourlyWeatherCode: number[]) {
+function makeArchiveResponse(sunshineDuration: number[], daylightDuration: number[]) {
 	return {
 		ok: true,
 		json: async () => ({
@@ -17,28 +17,28 @@ function makeArchiveResponse(hourlyWeatherCode: number[]) {
 				],
 				temperature_2m_max: [18.2, 19.456, 21.1, 20.0, 17.8, 22.3, 19.9],
 				temperature_2m_min: [10.1, 9.789, 11.2, 12.456, 8.5, 13.1, 10.0],
-				precipitation_sum: [0, 2.456, 0, 5.1, 0, 0.5, 0]
-			},
-			hourly: {
-				weather_code: hourlyWeatherCode
+				precipitation_sum: [0, 2.456, 0, 5.1, 0, 0.5, 0],
+				sunshine_duration: sunshineDuration,
+				daylight_duration: daylightDuration
 			}
 		})
 	};
 }
 
-// 168 hours (7 days): mostly partly-cloudy, with one afternoon's brief shower.
-// Open-Meteo's *daily* weathercode would label that whole day "light rain" (its
-// "most severe" convention), which would then dominate a naive daily-code mode.
-// The hourly mode should correctly read the week as mostly partly cloudy instead.
-const mostlyDryWithOneShower = [
-	...Array(80).fill(2),
-	...Array(6).fill(61),
-	...Array(82).fill(2)
-];
+// ~81% of daylight hours had sunshine, matching a genuinely sunny week.
+const mostlySunnyWeek = {
+	sunshine: [57600, 54162.96, 48444.29, 31750.93, 47883.58, 55042.73, 43200],
+	daylight: [59760.44, 59727.91, 59689.64, 59645.67, 59596.03, 59540.67, 59479.05]
+};
 
 describe('fetchWeeklyDigest', () => {
 	beforeEach(() => {
-		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse(mostlyDryWithOneShower)));
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(makeArchiveResponse(mostlySunnyWeek.sunshine, mostlySunnyWeek.daylight))
+		);
 	});
 
 	afterEach(() => {
@@ -61,9 +61,33 @@ describe('fetchWeeklyDigest', () => {
 		expect(digest.rainyDays).toBe(2);
 	});
 
-	it('picks the most frequent hourly weather code as the dominant condition, not a single severe hour', async () => {
+	it('describes a week with high sunshine-to-daylight ratio as mostly sunny', async () => {
 		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
-		expect(digest.dominantConditions).toBe('partly cloudy');
+		expect(digest.dominantConditions).toBe('mostly sunny');
+	});
+
+	it('describes a week with low sunshine-to-daylight ratio as mostly overcast', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				makeArchiveResponse(
+					[0, 0, 0, 0, 0, 0, 0],
+					[59760, 59727, 59689, 59645, 59596, 59540, 59479]
+				)
+			)
+		);
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.dominantConditions).toBe('mostly overcast');
+	});
+
+	it('describes a week with a middling sunshine-to-daylight ratio as a mix of sun and cloud', async () => {
+		const halfSunshine = mostlySunnyWeek.daylight.map((d) => d * 0.5);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(halfSunshine, mostlySunnyWeek.daylight))
+		);
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.dominantConditions).toBe('a mix of sun and cloud');
 	});
 
 	it('ends the window yesterday to account for ERA5 data lag on the current day', async () => {

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -66,12 +66,12 @@ describe('fetchWeeklyDigest', () => {
 		expect(digest.dominantConditions).toBe('partly cloudy');
 	});
 
-	it('ends the window a few days before today to account for ERA5 data lag', async () => {
+	it('ends the window yesterday to account for ERA5 data lag on the current day', async () => {
 		await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
 		const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
 		const params = new URL(calledUrl).searchParams;
-		expect(params.get('end_date')).toBe('2026-06-22');
-		expect(params.get('start_date')).toBe('2026-06-16');
+		expect(params.get('end_date')).toBe('2026-06-24');
+		expect(params.get('start_date')).toBe('2026-06-18');
 	});
 
 	it('throws when the API request fails', async () => {

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -56,9 +56,46 @@ describe('fetchWeeklyDigest', () => {
 		expect(digest.totalPrecipitation).toBe(8.1);
 	});
 
-	it('counts days with at least 1mm of rain as rainy days', async () => {
+	it('counts days with at least 1mm of rain as rainy days and names them', async () => {
 		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
 		expect(digest.rainyDays).toBe(2);
+		expect(digest.rainyDayNames).toEqual(['Tuesday', 'Thursday']);
+	});
+
+	it('returns no rainy day names when no day reached 1mm of rain', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					daily: {
+						time: [
+							'2026-06-15',
+							'2026-06-16',
+							'2026-06-17',
+							'2026-06-18',
+							'2026-06-19',
+							'2026-06-20',
+							'2026-06-21'
+						],
+						temperature_2m_max: [18.2, 19.5, 21.1, 20.0, 17.8, 22.3, 19.9],
+						temperature_2m_min: [10.1, 9.8, 11.2, 12.5, 8.5, 13.1, 10.0],
+						precipitation_sum: [0, 0.4, 0, 0.9, 0, 0, 0],
+						sunshine_duration: mostlySunnyWeek.sunshine,
+						daylight_duration: mostlySunnyWeek.daylight
+					}
+				})
+			})
+		);
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.rainyDays).toBe(0);
+		expect(digest.rainyDayNames).toEqual([]);
+	});
+
+	it('identifies the sunniest and cloudiest day of the week by sunshine-to-daylight ratio', async () => {
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.sunniestDay).toEqual({ day: 'Monday', sunshineHours: 16 });
+		expect(digest.cloudiestDay).toEqual({ day: 'Thursday', sunshineHours: 8.8 });
 	});
 
 	it('describes a week with high sunshine-to-daylight ratio as mostly sunny', async () => {

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWeeklyDigest } from './weeklyDigest';
 
-function makeArchiveResponse() {
+function makeArchiveResponse(hourlyWeatherCode: number[]) {
 	return {
 		ok: true,
 		json: async () => ({
@@ -17,16 +17,28 @@ function makeArchiveResponse() {
 				],
 				temperature_2m_max: [18.2, 19.456, 21.1, 20.0, 17.8, 22.3, 19.9],
 				temperature_2m_min: [10.1, 9.789, 11.2, 12.456, 8.5, 13.1, 10.0],
-				precipitation_sum: [0, 2.456, 0, 5.1, 0, 0.5, 0],
-				weather_code: [2, 61, 2, 63, 1, 2, 2]
+				precipitation_sum: [0, 2.456, 0, 5.1, 0, 0.5, 0]
+			},
+			hourly: {
+				weather_code: hourlyWeatherCode
 			}
 		})
 	};
 }
 
+// 168 hours (7 days): mostly partly-cloudy, with one afternoon's brief shower.
+// Open-Meteo's *daily* weathercode would label that whole day "light rain" (its
+// "most severe" convention), which would then dominate a naive daily-code mode.
+// The hourly mode should correctly read the week as mostly partly cloudy instead.
+const mostlyDryWithOneShower = [
+	...Array(80).fill(2),
+	...Array(6).fill(61),
+	...Array(82).fill(2)
+];
+
 describe('fetchWeeklyDigest', () => {
 	beforeEach(() => {
-		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse()));
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse(mostlyDryWithOneShower)));
 	});
 
 	afterEach(() => {
@@ -49,7 +61,7 @@ describe('fetchWeeklyDigest', () => {
 		expect(digest.rainyDays).toBe(2);
 	});
 
-	it('picks the most frequent weather code as the dominant condition', async () => {
+	it('picks the most frequent hourly weather code as the dominant condition, not a single severe hour', async () => {
 		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
 		expect(digest.dominantConditions).toBe('partly cloudy');
 	});

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWeeklyDigest } from './weeklyDigest';
+
+function makeArchiveResponse() {
+	return {
+		ok: true,
+		json: async () => ({
+			daily: {
+				time: [
+					'2026-06-15',
+					'2026-06-16',
+					'2026-06-17',
+					'2026-06-18',
+					'2026-06-19',
+					'2026-06-20',
+					'2026-06-21'
+				],
+				temperature_2m_max: [18.2, 19.456, 21.1, 20.0, 17.8, 22.3, 19.9],
+				temperature_2m_min: [10.1, 9.789, 11.2, 12.456, 8.5, 13.1, 10.0],
+				precipitation_sum: [0, 2.456, 0, 5.1, 0, 0.5, 0],
+				weather_code: [2, 61, 2, 63, 1, 2, 2]
+			}
+		})
+	};
+}
+
+describe('fetchWeeklyDigest', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse()));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns the highest max and lowest min temperature, rounded to one decimal', async () => {
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.tempHigh).toBe(22.3);
+		expect(digest.tempLow).toBe(8.5);
+	});
+
+	it('sums precipitation across the window, rounded to one decimal', async () => {
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.totalPrecipitation).toBe(8.1);
+	});
+
+	it('counts days with at least 1mm of rain as rainy days', async () => {
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.rainyDays).toBe(2);
+	});
+
+	it('picks the most frequent weather code as the dominant condition', async () => {
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.dominantConditions).toBe('partly cloudy');
+	});
+
+	it('ends the window a few days before today to account for ERA5 data lag', async () => {
+		await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+		const params = new URL(calledUrl).searchParams;
+		expect(params.get('end_date')).toBe('2026-06-22');
+		expect(params.get('start_date')).toBe('2026-06-16');
+	});
+
+	it('throws when the API request fails', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+		await expect(fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'))).rejects.toThrow(
+			'Open-Meteo error: 500'
+		);
+	});
+});

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -6,6 +6,10 @@ const READING_LON = -0.9781;
 const DATA_LAG_DAYS = 3;
 const WINDOW_DAYS = 7;
 
+// Fail fast rather than hanging until the platform's function timeout kicks in
+// and returns a 504 with no useful error.
+const REQUEST_TIMEOUT_MS = 5000;
+
 type OpenMeteoArchiveResponse = {
 	daily: {
 		time: string[];
@@ -79,7 +83,9 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 		timezone: 'Europe/London'
 	});
 
-	const response = await fetch(`https://archive-api.open-meteo.com/v1/archive?${params}`);
+	const response = await fetch(`https://archive-api.open-meteo.com/v1/archive?${params}`, {
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+	});
 	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
 
 	const data = (await response.json()) as OpenMeteoArchiveResponse;

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -17,44 +17,24 @@ type OpenMeteoArchiveResponse = {
 		temperature_2m_max: number[];
 		temperature_2m_min: number[];
 		precipitation_sum: number[];
-	};
-	hourly: {
-		weather_code: number[];
+		sunshine_duration: number[];
+		daylight_duration: number[];
 	};
 };
 
-const WMO_LABELS: Record<number, string> = {
-	0: 'clear sky',
-	1: 'mainly clear',
-	2: 'partly cloudy',
-	3: 'overcast',
-	45: 'fog',
-	48: 'icy fog',
-	51: 'light drizzle',
-	53: 'drizzle',
-	55: 'heavy drizzle',
-	61: 'light rain',
-	63: 'rain',
-	65: 'heavy rain',
-	71: 'light snow',
-	73: 'snow',
-	75: 'heavy snow',
-	77: 'snow grains',
-	80: 'light showers',
-	81: 'showers',
-	82: 'heavy showers',
-	85: 'light snow showers',
-	86: 'heavy snow showers',
-	95: 'thunderstorm',
-	96: 'thunderstorm & hail',
-	99: 'thunderstorm & heavy hail'
-};
+// ERA5's weather-code cloud estimates run high (see the on-page disclaimer), so rather
+// than categorise by weather code this compares actual recorded sunshine hours against
+// possible daylight hours — a much more reliable "how sunny was it" signal.
+function sunshineSummary(sunshineDurations: number[], daylightDurations: number[]): string {
+	const totalSunshine = sunshineDurations.reduce((a, b) => a + b, 0);
+	const totalDaylight = daylightDurations.reduce((a, b) => a + b, 0);
+	if (totalDaylight === 0) return 'unsettled';
 
-function dominantCode(codes: number[]): number {
-	const freq: Record<number, number> = {};
-	for (const c of codes) freq[c] = (freq[c] ?? 0) + 1;
-	const top = Object.entries(freq).sort((a, b) => b[1] - a[1])[0];
-	return top ? Number(top[0]) : 0;
+	const ratio = totalSunshine / totalDaylight;
+	if (ratio >= 0.65) return 'mostly sunny';
+	if (ratio >= 0.35) return 'a mix of sun and cloud';
+	if (ratio >= 0.15) return 'mostly cloudy';
+	return 'mostly overcast';
 }
 
 export type WeeklyDigest = {
@@ -82,8 +62,7 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 		longitude: String(READING_LON),
 		start_date: toDateStr(start),
 		end_date: toDateStr(end),
-		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum',
-		hourly: 'weather_code',
+		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,sunshine_duration,daylight_duration',
 		timezone: 'Europe/London'
 	});
 
@@ -93,11 +72,13 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
 
 	const data = (await response.json()) as OpenMeteoArchiveResponse;
-	const { temperature_2m_max, temperature_2m_min, precipitation_sum } = data.daily;
-
-	// Mode across every hour of the week, not the daily "most severe" label — a single
-	// brief shower shouldn't make an otherwise dry, sunny week read as "light drizzle".
-	const dominantLabel = WMO_LABELS[dominantCode(data.hourly.weather_code)] ?? 'unsettled';
+	const {
+		temperature_2m_max,
+		temperature_2m_min,
+		precipitation_sum,
+		sunshine_duration,
+		daylight_duration
+	} = data.daily;
 
 	return {
 		startDate: toDateStr(start),
@@ -106,6 +87,6 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 		tempLow: Math.round(Math.min(...temperature_2m_min) * 10) / 10,
 		totalPrecipitation: Math.round(precipitation_sum.reduce((a, b) => a + b, 0) * 10) / 10,
 		rainyDays: precipitation_sum.filter((p) => p >= 1).length,
-		dominantConditions: dominantLabel
+		dominantConditions: sunshineSummary(sunshine_duration, daylight_duration)
 	};
 }

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -1,9 +1,10 @@
 const READING_LAT = 51.4543;
 const READING_LON = -0.9781;
 
-// ERA5 archive data typically lags a few days behind real-time, so the
-// digest window ends a few days before today to avoid missing/null data.
-const DATA_LAG_DAYS = 3;
+// ERA5 archive data can lag behind real-time, so the digest window ends
+// yesterday rather than today to avoid missing/null data for the current,
+// still-in-progress day.
+const DATA_LAG_DAYS = 1;
 const WINDOW_DAYS = 7;
 
 // Fail fast rather than hanging until the platform's function timeout kicks in

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -37,6 +37,33 @@ function sunshineSummary(sunshineDurations: number[], daylightDurations: number[
 	return 'mostly overcast';
 }
 
+function weekdayName(dateStr: string): string {
+	return new Date(dateStr).toLocaleDateString('en-GB', { weekday: 'long', timeZone: 'UTC' });
+}
+
+function extremeSunshineDay(
+	dates: string[],
+	sunshineDurations: number[],
+	daylightDurations: number[],
+	pick: 'max' | 'min'
+): DaySummary {
+	let bestIndex = 0;
+	for (let i = 1; i < dates.length; i++) {
+		const ratio = sunshineDurations[i] / daylightDurations[i];
+		const bestRatio = sunshineDurations[bestIndex] / daylightDurations[bestIndex];
+		if (pick === 'max' ? ratio > bestRatio : ratio < bestRatio) bestIndex = i;
+	}
+	return {
+		day: weekdayName(dates[bestIndex]),
+		sunshineHours: Math.round((sunshineDurations[bestIndex] / 3600) * 10) / 10
+	};
+}
+
+export type DaySummary = {
+	day: string;
+	sunshineHours: number;
+};
+
 export type WeeklyDigest = {
 	startDate: string;
 	endDate: string;
@@ -44,6 +71,9 @@ export type WeeklyDigest = {
 	tempLow: number;
 	totalPrecipitation: number;
 	rainyDays: number;
+	rainyDayNames: string[];
+	sunniestDay: DaySummary;
+	cloudiestDay: DaySummary;
 	dominantConditions: string;
 };
 
@@ -73,6 +103,7 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 
 	const data = (await response.json()) as OpenMeteoArchiveResponse;
 	const {
+		time,
 		temperature_2m_max,
 		temperature_2m_min,
 		precipitation_sum,
@@ -80,13 +111,20 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 		daylight_duration
 	} = data.daily;
 
+	const rainyDayNames = time
+		.filter((_, i) => precipitation_sum[i] >= 1)
+		.map((dateStr) => weekdayName(dateStr));
+
 	return {
 		startDate: toDateStr(start),
 		endDate: toDateStr(end),
 		tempHigh: Math.round(Math.max(...temperature_2m_max) * 10) / 10,
 		tempLow: Math.round(Math.min(...temperature_2m_min) * 10) / 10,
 		totalPrecipitation: Math.round(precipitation_sum.reduce((a, b) => a + b, 0) * 10) / 10,
-		rainyDays: precipitation_sum.filter((p) => p >= 1).length,
+		rainyDays: rainyDayNames.length,
+		rainyDayNames,
+		sunniestDay: extremeSunshineDay(time, sunshine_duration, daylight_duration, 'max'),
+		cloudiestDay: extremeSunshineDay(time, sunshine_duration, daylight_duration, 'min'),
 		dominantConditions: sunshineSummary(sunshine_duration, daylight_duration)
 	};
 }

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -16,6 +16,8 @@ type OpenMeteoArchiveResponse = {
 		temperature_2m_max: number[];
 		temperature_2m_min: number[];
 		precipitation_sum: number[];
+	};
+	hourly: {
 		weather_code: number[];
 	};
 };
@@ -79,7 +81,8 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 		longitude: String(READING_LON),
 		start_date: toDateStr(start),
 		end_date: toDateStr(end),
-		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code',
+		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum',
+		hourly: 'weather_code',
 		timezone: 'Europe/London'
 	});
 
@@ -89,9 +92,11 @@ export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyD
 	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
 
 	const data = (await response.json()) as OpenMeteoArchiveResponse;
-	const { temperature_2m_max, temperature_2m_min, precipitation_sum, weather_code } = data.daily;
+	const { temperature_2m_max, temperature_2m_min, precipitation_sum } = data.daily;
 
-	const dominantLabel = WMO_LABELS[dominantCode(weather_code)] ?? 'unsettled';
+	// Mode across every hour of the week, not the daily "most severe" label — a single
+	// brief shower shouldn't make an otherwise dry, sunny week read as "light drizzle".
+	const dominantLabel = WMO_LABELS[dominantCode(data.hourly.weather_code)] ?? 'unsettled';
 
 	return {
 		startDate: toDateStr(start),

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -1,0 +1,99 @@
+const READING_LAT = 51.4543;
+const READING_LON = -0.9781;
+
+// ERA5 archive data typically lags a few days behind real-time, so the
+// digest window ends a few days before today to avoid missing/null data.
+const DATA_LAG_DAYS = 3;
+const WINDOW_DAYS = 7;
+
+type OpenMeteoArchiveResponse = {
+	daily: {
+		time: string[];
+		temperature_2m_max: number[];
+		temperature_2m_min: number[];
+		precipitation_sum: number[];
+		weather_code: number[];
+	};
+};
+
+const WMO_LABELS: Record<number, string> = {
+	0: 'clear sky',
+	1: 'mainly clear',
+	2: 'partly cloudy',
+	3: 'overcast',
+	45: 'fog',
+	48: 'icy fog',
+	51: 'light drizzle',
+	53: 'drizzle',
+	55: 'heavy drizzle',
+	61: 'light rain',
+	63: 'rain',
+	65: 'heavy rain',
+	71: 'light snow',
+	73: 'snow',
+	75: 'heavy snow',
+	77: 'snow grains',
+	80: 'light showers',
+	81: 'showers',
+	82: 'heavy showers',
+	85: 'light snow showers',
+	86: 'heavy snow showers',
+	95: 'thunderstorm',
+	96: 'thunderstorm & hail',
+	99: 'thunderstorm & heavy hail'
+};
+
+function dominantCode(codes: number[]): number {
+	const freq: Record<number, number> = {};
+	for (const c of codes) freq[c] = (freq[c] ?? 0) + 1;
+	const top = Object.entries(freq).sort((a, b) => b[1] - a[1])[0];
+	return top ? Number(top[0]) : 0;
+}
+
+export type WeeklyDigest = {
+	startDate: string;
+	endDate: string;
+	tempHigh: number;
+	tempLow: number;
+	totalPrecipitation: number;
+	rainyDays: number;
+	dominantConditions: string;
+};
+
+function toDateStr(date: Date): string {
+	return date.toISOString().slice(0, 10);
+}
+
+export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyDigest> {
+	const end = new Date(now);
+	end.setDate(end.getDate() - DATA_LAG_DAYS);
+	const start = new Date(end);
+	start.setDate(start.getDate() - (WINDOW_DAYS - 1));
+
+	const params = new URLSearchParams({
+		latitude: String(READING_LAT),
+		longitude: String(READING_LON),
+		start_date: toDateStr(start),
+		end_date: toDateStr(end),
+		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code',
+		timezone: 'Europe/London'
+	});
+
+	const response = await fetch(`https://archive-api.open-meteo.com/v1/archive?${params}`);
+	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
+
+	const data = (await response.json()) as OpenMeteoArchiveResponse;
+	const { temperature_2m_max, temperature_2m_min, precipitation_sum, weather_code } = data.daily;
+
+	const dominantLabel = WMO_LABELS[dominantCode(weather_code)] ?? 'unsettled';
+
+	return {
+		startDate: toDateStr(start),
+		endDate: toDateStr(end),
+		tempHigh: Math.round(Math.max(...temperature_2m_max) * 10) / 10,
+		tempLow: Math.round(Math.min(...temperature_2m_min) * 10) / 10,
+		totalPrecipitation: Math.round(precipitation_sum.reduce((a, b) => a + b, 0) * 10) / 10,
+		rainyDays: precipitation_sum.filter((p) => p >= 1).length,
+		dominantConditions: dominantLabel
+	};
+}

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -34,5 +34,9 @@
 			{/if}
 		</div>
 		<p class="summary">Mostly {digest.dominantConditions}.</p>
+		<p class="conditions-note">
+			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
+			approximate guide only - in particular the cloud amounts seem to be greatly overstated.
+		</p>
 	</section>
 {/if}

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -11,6 +11,10 @@
 		return `${start} – ${end}`;
 	}
 
+	function capitalize(text: string): string {
+		return text.charAt(0).toUpperCase() + text.slice(1);
+	}
+
 	onMount(async () => {
 		try {
 			const res = await fetch('/api/weekly-digest');
@@ -33,7 +37,7 @@
 				<span>{digest.rainyDays} wet {digest.rainyDays === 1 ? 'day' : 'days'}</span>
 			{/if}
 		</div>
-		<p class="summary">Mostly {digest.dominantConditions}.</p>
+		<p class="summary">{capitalize(digest.dominantConditions)}.</p>
 		<p class="conditions-note">
 			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
 			approximate guide only - in particular the cloud amounts seem to be greatly overstated.

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -15,6 +15,11 @@
 		return text.charAt(0).toUpperCase() + text.slice(1);
 	}
 
+	function formatDayList(days: string[]): string {
+		if (days.length === 1) return days[0];
+		return `${days.slice(0, -1).join(', ')} and ${days[days.length - 1]}`;
+	}
+
 	onMount(async () => {
 		try {
 			const res = await fetch('/api/weekly-digest');
@@ -38,6 +43,13 @@
 			{/if}
 		</div>
 		<p class="summary">{capitalize(digest.dominantConditions)}.</p>
+		<p class="detail">
+			Sunniest day: {digest.sunniestDay.day} ({digest.sunniestDay.sunshineHours}h sun) · Cloudiest:
+			{digest.cloudiestDay.day} ({digest.cloudiestDay.sunshineHours}h sun)
+		</p>
+		{#if digest.rainyDayNames.length > 0}
+			<p class="detail">Rain fell on {formatDayList(digest.rainyDayNames)}.</p>
+		{/if}
 		<p class="conditions-note">
 			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
 			approximate guide only - in particular the cloud amounts seem to be greatly overstated.

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -52,7 +52,7 @@
 		{/if}
 		<p class="conditions-note">
 			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
-			approximate guide only - in particular the cloud amounts seem to be greatly overstated.
+			approximate guide only
 		</p>
 	</section>
 {/if}

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { WeeklyDigest } from '$lib/api/weeklyDigest';
+
+	let digest = $state<WeeklyDigest | null>(null);
+
+	function formatRange(startDate: string, endDate: string): string {
+		const opts: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'long' };
+		const start = new Date(startDate).toLocaleDateString('en-GB', opts);
+		const end = new Date(endDate).toLocaleDateString('en-GB', opts);
+		return `${start} – ${end}`;
+	}
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/api/weekly-digest');
+			if (res.ok) digest = (await res.json()) as WeeklyDigest;
+		} catch {
+			// silently fail — weather data is supplementary
+		}
+	});
+</script>
+
+{#if digest}
+	<section class="weekly-digest">
+		<h2>Last Week in Reading</h2>
+		<p class="range">{formatRange(digest.startDate, digest.endDate)}</p>
+		<div class="stats">
+			<span>↑{digest.tempHigh}°C</span>
+			<span>↓{digest.tempLow}°C</span>
+			<span>{digest.totalPrecipitation}mm rain</span>
+			{#if digest.rainyDays > 0}
+				<span>{digest.rainyDays} wet {digest.rainyDays === 1 ? 'day' : 'days'}</span>
+			{/if}
+		</div>
+		<p class="summary">Mostly {digest.dominantConditions}.</p>
+	</section>
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,8 +31,6 @@
 
 <h1>Weather Forecast For Reading & Berkshire</h1>
 
-<WeeklyDigest />
-
 <PostList posts={data.posts.posts.nodes} preview={true} />
 
 {#if data.latestSeasonalPost}
@@ -50,3 +48,5 @@
 	<p>Looking for older posts?</p>
 	<a href="/archives">Check out the archives</a>
 </div>
+
+<WeeklyDigest />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import '../styles/index.css';
 	import OnThisDay from '$lib/components/OnThisDay.svelte';
 	import PostList from '$lib/components/PostList.svelte';
+	import WeeklyDigest from '$lib/components/WeeklyDigest.svelte';
 
 	const jsonLd = $derived({
 		'@context': 'https://schema.org',
@@ -29,6 +30,8 @@
 </svelte:head>
 
 <h1>Weather Forecast For Reading & Berkshire</h1>
+
+<WeeklyDigest />
 
 <PostList posts={data.posts.posts.nodes} preview={true} />
 

--- a/src/routes/api/weekly-digest/+server.ts
+++ b/src/routes/api/weekly-digest/+server.ts
@@ -4,13 +4,26 @@ import { getCache, setCache } from '$lib/server/cache';
 import type { RequestHandler } from './$types';
 
 const TTL_MS = 12 * 60 * 60 * 1000;
+const ERROR_TTL_MS = 5 * 60 * 1000;
 
 export const GET: RequestHandler = async () => {
 	const cacheKey = `weekly-digest-${new Date().toISOString().slice(0, 10)}`;
 	const cached = getCache<WeeklyDigest>(cacheKey);
 	if (cached) return json(cached);
 
-	const data = await fetchWeeklyDigest();
-	setCache(cacheKey, data, TTL_MS);
-	return json(data);
+	const errorCacheKey = `${cacheKey}-error`;
+	if (getCache<true>(errorCacheKey)) {
+		return json({ error: 'Weekly digest temporarily unavailable' }, { status: 502 });
+	}
+
+	try {
+		const data = await fetchWeeklyDigest();
+		setCache(cacheKey, data, TTL_MS);
+		return json(data);
+	} catch (err) {
+		// Avoid hammering an already-failing/rate-limited upstream on every request.
+		setCache(errorCacheKey, true, ERROR_TTL_MS);
+		console.error('fetchWeeklyDigest failed:', err);
+		return json({ error: 'Weekly digest temporarily unavailable' }, { status: 502 });
+	}
 };

--- a/src/routes/api/weekly-digest/+server.ts
+++ b/src/routes/api/weekly-digest/+server.ts
@@ -1,0 +1,16 @@
+import { json } from '@sveltejs/kit';
+import { fetchWeeklyDigest, type WeeklyDigest } from '$lib/api/weeklyDigest';
+import { getCache, setCache } from '$lib/server/cache';
+import type { RequestHandler } from './$types';
+
+const TTL_MS = 12 * 60 * 60 * 1000;
+
+export const GET: RequestHandler = async () => {
+	const cacheKey = `weekly-digest-${new Date().toISOString().slice(0, 10)}`;
+	const cached = getCache<WeeklyDigest>(cacheKey);
+	if (cached) return json(cached);
+
+	const data = await fetchWeeklyDigest();
+	setCache(cacheKey, data, TTL_MS);
+	return json(data);
+};

--- a/src/routes/api/weekly-digest/server.spec.ts
+++ b/src/routes/api/weekly-digest/server.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GET } from './+server';
+
+vi.mock('$lib/api/weeklyDigest', () => ({
+	fetchWeeklyDigest: vi.fn().mockResolvedValue({
+		startDate: '2026-06-16',
+		endDate: '2026-06-22',
+		tempHigh: 22.3,
+		tempLow: 8.5,
+		totalPrecipitation: 8.1,
+		rainyDays: 2,
+		dominantConditions: 'partly cloudy'
+	})
+}));
+
+describe('GET /api/weekly-digest', () => {
+	it('returns 200 with the weekly digest', async () => {
+		const response = await GET({} as Parameters<typeof GET>[0]);
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.dominantConditions).toBe('partly cloudy');
+		expect(body.totalPrecipitation).toBe(8.1);
+	});
+});

--- a/src/routes/api/weekly-digest/server.spec.ts
+++ b/src/routes/api/weekly-digest/server.spec.ts
@@ -16,6 +16,9 @@ const mockDigest = {
 	tempLow: 8.5,
 	totalPrecipitation: 8.1,
 	rainyDays: 2,
+	rainyDayNames: ['Tuesday', 'Thursday'],
+	sunniestDay: { day: 'Saturday', sunshineHours: 12.4 },
+	cloudiestDay: { day: 'Sunday', sunshineHours: 1.2 },
 	dominantConditions: 'partly cloudy'
 };
 

--- a/src/routes/api/weekly-digest/server.spec.ts
+++ b/src/routes/api/weekly-digest/server.spec.ts
@@ -1,24 +1,66 @@
-import { describe, expect, it, vi } from 'vitest';
-import { GET } from './+server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('$lib/api/weeklyDigest', () => ({
-	fetchWeeklyDigest: vi.fn().mockResolvedValue({
-		startDate: '2026-06-16',
-		endDate: '2026-06-22',
-		tempHigh: 22.3,
-		tempLow: 8.5,
-		totalPrecipitation: 8.1,
-		rainyDays: 2,
-		dominantConditions: 'partly cloudy'
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn((key: string) => cacheStore.get(key) ?? null),
+	setCache: vi.fn((key: string, data: unknown) => {
+		cacheStore.set(key, data);
 	})
 }));
 
+const mockDigest = {
+	startDate: '2026-06-16',
+	endDate: '2026-06-22',
+	tempHigh: 22.3,
+	tempLow: 8.5,
+	totalPrecipitation: 8.1,
+	rainyDays: 2,
+	dominantConditions: 'partly cloudy'
+};
+
+vi.mock('$lib/api/weeklyDigest', () => ({
+	fetchWeeklyDigest: vi.fn()
+}));
+
+import { fetchWeeklyDigest } from '$lib/api/weeklyDigest';
+import { GET } from './+server';
+
+beforeEach(() => {
+	cacheStore.clear();
+	vi.clearAllMocks();
+});
+
 describe('GET /api/weekly-digest', () => {
 	it('returns 200 with the weekly digest', async () => {
+		vi.mocked(fetchWeeklyDigest).mockResolvedValue(mockDigest);
+
 		const response = await GET({} as Parameters<typeof GET>[0]);
+
 		expect(response.status).toBe(200);
 		const body = await response.json();
 		expect(body.dominantConditions).toBe('partly cloudy');
 		expect(body.totalPrecipitation).toBe(8.1);
+	});
+
+	it('returns a 502 with an error body when the upstream fetch fails', async () => {
+		vi.mocked(fetchWeeklyDigest).mockRejectedValue(new Error('Open-Meteo error: 429'));
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(502);
+		const body = await response.json();
+		expect(body.error).toBeTruthy();
+	});
+
+	it('does not call the upstream again while a recent failure is cached', async () => {
+		vi.mocked(fetchWeeklyDigest).mockRejectedValue(new Error('Open-Meteo error: 429'));
+		await GET({} as Parameters<typeof GET>[0]);
+
+		vi.mocked(fetchWeeklyDigest).mockClear();
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(502);
+		expect(fetchWeeklyDigest).not.toHaveBeenCalled();
 	});
 });

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -122,6 +122,38 @@ main {
 	}
 }
 
+.weekly-digest {
+	border: 5px solid var(--nav);
+	margin-bottom: 2rem;
+	padding: 1rem;
+	text-align: center;
+	background: var(--white);
+
+	/* biome-ignore lint/style/noDescendingSpecificity: targets .weekly-digest h2, unrelated to main .post h2 */
+	h2 {
+		margin: 0 0 0.75rem;
+	}
+
+	.range {
+		margin: 0 0 0.5rem;
+		font-size: 0.85rem;
+		color: #767676;
+	}
+
+	.stats {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 1rem;
+		font-size: 1.125rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.summary {
+		margin: 0;
+	}
+}
+
 .older-posts {
 	text-align: center;
 	margin: 0 0 2rem 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -152,6 +152,13 @@ main {
 	.summary {
 		margin: 0;
 	}
+
+	.conditions-note {
+		font-size: 0.8rem;
+		color: #767676;
+		margin: 0.75rem 0 0;
+		font-style: italic;
+	}
 }
 
 .older-posts {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -153,6 +153,12 @@ main {
 		margin: 0;
 	}
 
+	.detail {
+		margin: 0.35rem 0 0;
+		font-size: 0.9rem;
+		color: #555;
+	}
+
 	.conditions-note {
 		font-size: 0.8rem;
 		color: #767676;


### PR DESCRIPTION
## Summary
- Pivots #401 away from an email digest towards a **Weekly Digest box on the homepage**: last 7 days of actual Reading weather (temp high/low, total rainfall, dominant conditions), reusing the same Open-Meteo ERA5 archive API already powering "On This Day"
- New card sits right after the `<h1>` on the homepage — the highest-visibility slot, as a return-visit driver
- Styled to match the existing `.latest-seasonal` card (flat, thick navy border, centred, no `<style>` blocks — global CSS per repo convention)
- Data fetched client-side (`onMount`, same pattern as `OnThisDay.svelte`) via a new `/api/weekly-digest` route with a 12h server-side cache
- Digest window ends 3 days before "today" to account for ERA5 archive data lag

## Why not email?
The original issue proposed a subscribe funnel + weekly email. That's a bigger commitment (new page, footer/CTA rewrite, ongoing manual sending or a mail provider integration) for an unproven idea. A homepage card reuses existing infrastructure, ships immediately, and tests the same "here's what actually happened last week" content hook without any new operational burden.

Closes #401

## Test plan
- [x] `yarn test:unit run` — 98/98 tests pass (new: `weeklyDigest.spec.ts`, `server.spec.ts` for the new route)
- [x] `yarn lint` — clean
- [x] `yarn check` (svelte-check) — 0 errors
- [x] Ran `yarn dev`, hit `/api/weekly-digest` directly — returns live Open-Meteo data
- [x] Rendered the homepage in headless Chromium — card appears under the `<h1>`, styled consistently with the seasonal forecast card