### PR TITLE
perf: fix LCP image loading on post and home pages

### DIFF
--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <ul>
-	{#each posts as post}
+	{#each posts as post, i}
 		<li>
 			<article class="post">
 				<a href="/{post.slug}">
@@ -24,7 +24,8 @@
 							alt=""
 							width={post.featuredImage.node.mediaDetails?.width ?? undefined}
 							height={post.featuredImage.node.mediaDetails?.height ?? undefined}
-							loading="lazy"
+							loading={i === 0 ? 'eager' : 'lazy'}
+							fetchpriority={i === 0 ? 'high' : undefined}
 						/>
 					{/if}
 					<h2>{post.title}</h2>

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -125,7 +125,7 @@
 			alt=""
 			width={data.post.featuredImage.node.mediaDetails?.width ?? undefined}
 			height={data.post.featuredImage.node.mediaDetails?.height ?? undefined}
-			loading="lazy"
+			fetchpriority="high"
 		/>
 	{/if}
 	<div class="content">{@html sanitizedContent}</div>


### PR DESCRIPTION
## What

Fix two Largest Contentful Paint (LCP) regressions caused by `loading="lazy"` being applied to above-the-fold hero images.

## Changes

### `src/routes/[slug]/+page.svelte`

The featured image at the top of every post page is almost always the LCP element — it is visually prominent, rendered above the fold, and the largest visible image on the page. Using `loading="lazy"` on it tells the browser to defer the fetch until the image enters the viewport, which directly delays LCP.

- Removed `loading="lazy"`
- Added `fetchpriority="high"` so the browser fetches this image at high priority as soon as it discovers it in the HTML

### `src/lib/components/PostList.svelte`

The post list is used on the home page (preview mode, showing the 2 most recent posts) and the seasonal forecasts page. The first post's image is above the fold in most viewports and is a strong LCP candidate.

- Added index `i` to the `{#each posts as post, i}` loop
- First image (`i === 0`): `loading="eager"` + `fetchpriority="high"` — fetched immediately
- Remaining images (`i > 0`): `loading="lazy"` unchanged — deferred until the user scrolls

## Why it matters

Using `loading="lazy"` on an LCP image is a [well-documented Core Web Vitals anti-pattern](https://web.dev/lcp/#lazy-loading). The browser skips the image in its preload scan and only starts fetching it after layout, adding hundreds of milliseconds to LCP. `fetchpriority="high"` further ensures the resource competes at the top of the network queue.

All 117 unit tests pass. No behaviour or visual changes — the images still render identically; only the fetch timing changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRtCqwWuHcryMjMjjkuSgV)_