### PR TITLE
chore(ts): fix type inconsistency, redundant cast, and spurious optional chaining

### DIFF
--- a/src/lib/components/Comment.svelte
+++ b/src/lib/components/Comment.svelte
@@ -58,11 +58,11 @@
 
 <li class="comment">
 	<small>
-		By <strong>{comment?.author.node.name}</strong> on <time datetime={comment?.date}>{formatDate(comment?.date)}</time>:
+		By <strong>{comment.author.node.name}</strong> on <time datetime={comment.date}>{formatDate(comment.date)}</time>:
 	</small>
-	<p>{@html sanitize(comment?.content ?? '')}</p>
+	<p>{@html sanitize(comment.content)}</p>
 
-	{#if comment?.replies.length > 0}
+	{#if comment.replies.length > 0}
 		<ul class="comment-replies">
 			{#each comment.replies as reply}
 				<Comment comment={reply} {postId} {replyForms} />
@@ -70,9 +70,9 @@
 		</ul>
 	{/if}
 
-	<button class="reply-button" onclick={() => toggleReplyForm(comment?.id)} aria-label="Reply to {comment?.author.node.name}">Reply</button>
+	<button class="reply-button" onclick={() => toggleReplyForm(comment.id)} aria-label="Reply to {comment.author.node.name}">Reply</button>
 
-	{#if $replyForms[comment?.id]}
+	{#if $replyForms[comment.id]}
 		<AddComment {postId} parentCommentId={comment.id} />
 	{/if}
 </li>

--- a/src/lib/graphql/api.ts
+++ b/src/lib/graphql/api.ts
@@ -29,7 +29,7 @@ export async function fetchGraphQL<T = Record<string, unknown>>(
 		throw new Error('Failed to fetch data');
 	}
 
-	return json.data as T;
+	return json.data;
 }
 
 type AddCommentResponse = { createComment: { success: boolean } | null };

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -26,7 +26,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 	const [response, latestSlug, latestSeasonal] = await Promise.all([
 		fetchGraphQL<GetPostBySlugResponse>(GET_POST_BY_SLUG, { slug }, fetch),
 		fetchLatestPostSlug(fetch),
-		fetchGraphQL<LatestSeasonalPostResponse>(GET_LATEST_SEASONAL_POST_QUERY, {}, fetch)
+		fetchGraphQL<LatestSeasonalPostResponse>(GET_LATEST_SEASONAL_POST_QUERY, {}, fetch).catch(() => null)
 	]);
 
 	if (!response.postBy) {

--- a/src/routes/[slug]/page.spec.ts
+++ b/src/routes/[slug]/page.spec.ts
@@ -40,7 +40,8 @@ describe('[slug] page load', () => {
 	it('returns post data and isLatest=true when slug matches the newest post', async () => {
 		vi.mocked(fetchGraphQL)
 			.mockResolvedValueOnce({ postBy: mockPost })
-			.mockResolvedValueOnce({ posts: { nodes: [{ slug: 'test-post' }] } });
+			.mockResolvedValueOnce({ posts: { nodes: [{ slug: 'test-post' }] } })
+			.mockResolvedValueOnce({ posts: { nodes: [] } });
 
 		const result = (await load({ params: { slug: 'test-post' } } as Parameters<typeof load>[0])) as SlugLoadResult;
 
@@ -52,7 +53,8 @@ describe('[slug] page load', () => {
 	it('returns isLatest=false when the slug is not the newest post', async () => {
 		vi.mocked(fetchGraphQL)
 			.mockResolvedValueOnce({ postBy: mockPost })
-			.mockResolvedValueOnce({ posts: { nodes: [{ slug: 'newer-post' }] } });
+			.mockResolvedValueOnce({ posts: { nodes: [{ slug: 'newer-post' }] } })
+			.mockResolvedValueOnce({ posts: { nodes: [] } });
 
 		const result = (await load({ params: { slug: 'test-post' } } as Parameters<typeof load>[0])) as SlugLoadResult;
 
@@ -63,6 +65,7 @@ describe('[slug] page load', () => {
 	it('throws a 404 error when postBy is null', async () => {
 		vi.mocked(fetchGraphQL)
 			.mockResolvedValueOnce({ postBy: null })
+			.mockResolvedValueOnce({ posts: { nodes: [] } })
 			.mockResolvedValueOnce({ posts: { nodes: [] } });
 
 		await expect(


### PR DESCRIPTION
## Summary

Three focused TypeScript correctness fixes identified during the Monday typing audit:

### 1. `[slug]/+page.server.ts` — missing `.catch(() => null)` on seasonal fetch (resilience + type gap)

The `fetchGraphQL<LatestSeasonalPostResponse>` call for the latest seasonal post was not guarded with `.catch(() => null)`, unlike the identical call in `+page.server.ts`. This meant:

- If the seasonal GraphQL endpoint fails, `Promise.all` rejects and the entire post page returns a 500 error — silently breaking individual post pages whenever the seasonal API is down.
- TypeScript typed `latestSeasonal` as `LatestSeasonalPostResponse` (non-nullable), yet line 40 used `latestSeasonal?.posts?.nodes?.[0] ?? null` — all the optional chaining was misleading because the type said it could never be null.

Adding `.catch(() => null)` makes the type `LatestSeasonalPostResponse | null`, which is consistent with the existing defensive access pattern, and matches the established pattern in `+page.server.ts`.

### 2. `api.ts` — redundant `as T` cast removed

`json` was explicitly declared as `GraphQLResponse<T>`, which has `data: T`. The `return json.data as T` cast was therefore redundant — `json.data` is already typed as `T` and TypeScript doesn't require the assertion. Removed to reduce noise.

### 3. `Comment.svelte` — remove spurious `?.` optional chaining on non-nullable `comment` prop

`comment` is typed as `ThreadedComment` (a non-nullable type). Every property (`id`, `date`, `content`, `author`, `replies`) is also non-nullable per `GqlComment`. Yet the template used `comment?.` throughout (7 occurrences), misrepresenting the component's contract and obscuring any future refactor that makes `comment` genuinely optional. Replaced all `comment?.` with `comment.` in the template.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQirBgWJcoLLyGfQ5kDDwX)_