### PR TITLE
test: add 7 unit tests covering previously untested branches

### DIFF
--- a/src/lib/api/weekInHistory.spec.ts
+++ b/src/lib/api/weekInHistory.spec.ts
@@ -107,4 +107,19 @@ describe('fetchWeekInHistory', () => {
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		await expect(fetchWeekInHistory(NOW)).rejects.toThrow('Open-Meteo error: 500');
 	});
+
+	it('throws with a descriptive message when the archive response contains no dates in the window', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					daily: { time: [], temperature_2m_max: [], temperature_2m_min: [], precipitation_sum: [] }
+				})
+			})
+		);
+		await expect(fetchWeekInHistory(NOW)).rejects.toThrow(
+			'No historical data available for this window'
+		);
+	});
 });

--- a/src/lib/api/weeklyDigest.spec.ts
+++ b/src/lib/api/weeklyDigest.spec.ts
@@ -127,6 +127,26 @@ describe('fetchWeeklyDigest', () => {
 		expect(digest.dominantConditions).toBe('a mix of sun and cloud');
 	});
 
+	it('describes a week with roughly a quarter of daylight hours as sunshine as mostly cloudy', async () => {
+		const quarterSunshine = mostlySunnyWeek.daylight.map((d) => d * 0.25);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(quarterSunshine, mostlySunnyWeek.daylight))
+		);
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.dominantConditions).toBe('mostly cloudy');
+	});
+
+	it('describes a week with zero daylight duration as unsettled', async () => {
+		const zeroDaylight = [0, 0, 0, 0, 0, 0, 0];
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(zeroDaylight, zeroDaylight))
+		);
+		const digest = await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
+		expect(digest.dominantConditions).toBe('unsettled');
+	});
+
 	it('ends the window yesterday to account for ERA5 data lag on the current day', async () => {
 		await fetchWeeklyDigest(new Date('2026-06-25T12:00:00Z'));
 		const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;

--- a/src/lib/server/cache.spec.ts
+++ b/src/lib/server/cache.spec.ts
@@ -39,4 +39,15 @@ describe('getCache', () => {
 		expect(getCache('key-a')).toBe('alpha');
 		expect(getCache('key-b')).toBe('beta');
 	});
+
+	it('overwrites an existing key so the new value is returned and the new TTL applies', () => {
+		setCache('overwrite-key', 'original', 10_000);
+		vi.advanceTimersByTime(5_000);
+		setCache('overwrite-key', 'updated', 1_000);
+		// Value should be the newly written one
+		expect(getCache('overwrite-key')).toBe('updated');
+		// The new 1-second TTL should expire after advancing past it
+		vi.advanceTimersByTime(1_001);
+		expect(getCache('overwrite-key')).toBeNull();
+	});
 });

--- a/src/routes/api/comment/server.spec.ts
+++ b/src/routes/api/comment/server.spec.ts
@@ -5,6 +5,9 @@ import { POST } from './+server';
 vi.mock('$lib/graphql/api', () => ({
 	addComment: vi.fn().mockResolvedValue({ success: true })
 }));
+
+import { addComment } from '$lib/graphql/api';
+
 const validPostId = btoa('post:123');
 
 function makeRequest(body: unknown, headerOverrides: Record<string, string> = {}) {
@@ -85,5 +88,31 @@ describe('POST /api/comment', () => {
 		expect(response.status).toBe(200);
 		const data = await response.json();
 		expect(data.success).toBe(true);
+	});
+
+	it('returns 422 when addComment resolves with success: false', async () => {
+		vi.mocked(addComment).mockResolvedValueOnce({ success: false });
+		const request = makeRequest({
+			postId: validPostId,
+			content: 'Great post!',
+			name: 'Alice',
+			email: 'alice@example.com'
+		});
+		const response = await POST({ request } as Parameters<typeof POST>[0]);
+		expect(response.status).toBe(422);
+		const data = await response.json();
+		expect(data.success).toBe(false);
+	});
+
+	it('returns 502 when addComment throws', async () => {
+		vi.mocked(addComment).mockRejectedValueOnce(new Error('GraphQL error'));
+		const request = makeRequest({
+			postId: validPostId,
+			content: 'Great post!',
+			name: 'Alice',
+			email: 'alice@example.com'
+		});
+		const response = await POST({ request } as Parameters<typeof POST>[0]);
+		expect(response.status).toBe(502);
 	});
 });

--- a/src/routes/api/subscribe/server.spec.ts
+++ b/src/routes/api/subscribe/server.spec.ts
@@ -87,4 +87,20 @@ describe('POST /api/subscribe', () => {
 		const data = await response.json();
 		expect(data.message).toBe('Something went wrong. Please try again.');
 	});
+
+	it('passes through non-200 status codes and the upstream error message', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: false,
+				status: 422,
+				json: async () => ({ message: 'Email already registered' })
+			})
+		);
+		const request = makeRequest({ name: 'Alice', email: 'alice@example.com' });
+		const response = await POST({ request } as Parameters<typeof POST>[0]);
+		expect(response.status).toBe(422);
+		const data = await response.json();
+		expect(data.message).toBe('Email already registered');
+	});
 });


### PR DESCRIPTION
## Summary

- **`weeklyDigest`**: adds tests for the `'mostly cloudy'` (sunshine/daylight ratio 0.15–0.35) and `'unsettled'` (zero total daylight) branches of `sunshineSummary` — both were completely unreachable from the existing test suite
- **`weekInHistory`**: adds a test for the `'No historical data available for this window'` error path, triggered when the Open-Meteo archive response contains no dates matching any historical year
- **`cache`**: adds a test confirming that `setCache` on an existing key replaces both the value and the TTL, verifying the overwrite behaviour that all cache consumers implicitly rely on
- **`POST /api/comment`**: adds tests for the 422 path (`addComment` resolves with `{ success: false }`) and the 502 path (`addComment` throws), two reachable branches that had no coverage
- **`POST /api/subscribe`**: adds a test confirming that non-200 HTTP status codes and error messages from the upstream WordPress endpoint are passed through to the caller

All 124 tests pass; `yarn lint` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDe8ME4TdbP75hKaGnVjKA)_