### PR TITLE
chore(a11y/seo): accessibility and SEO improvements

### DIFF
--- a/src/lib/components/OnThisDay.svelte
+++ b/src/lib/components/OnThisDay.svelte
@@ -73,7 +73,7 @@
 			<ul class="on-this-day-list">
 				{#each historicalPosts as post}
 					<li>
-						<span class="year">{getYear(post.date)}</span>
+						<time class="year" datetime={post.date}>{getYear(post.date)}</time>
 						<a href="/{post.slug}">{post.title}</a>
 					</li>
 				{/each}

--- a/src/lib/components/WeekInHistory.svelte
+++ b/src/lib/components/WeekInHistory.svelte
@@ -20,13 +20,13 @@
 		<p class="range">{history.windowLabel} · {history.yearsOfData} years of records</p>
 		<ul class="records">
 			<li>
-				🌡️ Hottest day: <strong>{history.hottestDay.value}°C</strong> in {history.hottestDay.year}
+				<span aria-hidden="true">🌡️</span> Hottest day: <strong>{history.hottestDay.value}°C</strong> in {history.hottestDay.year}
 			</li>
 			<li>
-				❄️ Coldest day: <strong>{history.coldestDay.value}°C</strong> in {history.coldestDay.year}
+				<span aria-hidden="true">❄️</span> Coldest day: <strong>{history.coldestDay.value}°C</strong> in {history.coldestDay.year}
 			</li>
 			<li>
-				🌧️ Wettest week (total rainfall): <strong>{history.wettestWeek.value}mm</strong> in {history
+				<span aria-hidden="true">🌧️</span> Wettest week (total rainfall): <strong>{history.wettestWeek.value}mm</strong> in {history
 					.wettestWeek.year}
 			</li>
 		</ul>

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -35,8 +35,8 @@
 		<h2>Last Week in Reading</h2>
 		<p class="range">{formatRange(digest.startDate, digest.endDate)}</p>
 		<div class="stats">
-			<span>↑{digest.tempHigh}°C</span>
-			<span>↓{digest.tempLow}°C</span>
+			<span><span aria-hidden="true">↑</span><span class="sr-only">High: </span>{digest.tempHigh}°C</span>
+			<span><span aria-hidden="true">↓</span><span class="sr-only">Low: </span>{digest.tempLow}°C</span>
 			<span>{digest.totalPrecipitation}mm rain</span>
 			{#if digest.rainyDays > 0}
 				<span>{digest.rainyDays} wet {digest.rainyDays === 1 ? 'day' : 'days'}</span>

--- a/src/lib/graphql/queries/getPostBySlug.ts
+++ b/src/lib/graphql/queries/getPostBySlug.ts
@@ -9,6 +9,7 @@ const GET_POST_BY_SLUG = `
       content
       featuredImage {
         node {
+          altText
           sourceUrl(size: MEDIUM_LARGE)
           srcSet(size: MEDIUM_LARGE)
           mediaDetails {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export type GqlComment = {
 export type ThreadedComment = GqlComment & { replies: ThreadedComment[] };
 
 export type GqlPostFeaturedImageNode = {
+	altText?: string;
 	sourceUrl: string;
 	srcSet?: string;
 	mediaDetails?: {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -60,8 +60,8 @@
 
 <footer>
 	<section class="post">
-		<h2>Be notified of new posts by e-mail</h2>
-<form id="subscribe-form" onsubmit={handleSubmit}>
+		<h2 id="subscribe-heading">Be notified of new posts by e-mail</h2>
+<form id="subscribe-form" aria-labelledby="subscribe-heading" onsubmit={handleSubmit}>
 			<label for="subscribe-name">
 				Name:
 				<input id="subscribe-name" autocomplete="name" type="text" bind:value={name} required aria-required="true" />

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -96,13 +96,16 @@
 	<meta name="description" content={postDescription} />
 	<meta property="og:title" content={postTitle} />
 	<meta property="og:description" content={postDescription} />
-	{#if data.post.featuredImage?.node?.sourceUrl}
-		<meta property="og:image" content={data.post.featuredImage.node.sourceUrl} />
-		<meta name="twitter:image" content={data.post.featuredImage.node.sourceUrl} />
-	{/if}
+	<meta
+		property="og:image"
+		content={data.post.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'}
+	/>
+	<meta
+		name="twitter:image"
+		content={data.post.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'}
+	/>
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content={postUrl} />
-	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content={postTitle} />
 	<meta name="twitter:description" content={postDescription} />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
@@ -122,7 +125,7 @@
 			src={data.post.featuredImage.node.sourceUrl}
 			srcset={data.post.featuredImage.node.srcSet}
 			sizes="(min-width: 768px) 700px, 100vw"
-			alt=""
+			alt={data.post.featuredImage.node.altText ?? ''}
 			width={data.post.featuredImage.node.mediaDetails?.width ?? undefined}
 			height={data.post.featuredImage.node.mediaDetails?.height ?? undefined}
 			fetchpriority="high"

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -10,6 +10,14 @@
 		'July', 'August', 'September', 'October', 'November', 'December'
 	];
 
+	const jsonLd = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'ImageGallery',
+		name: `Photo Gallery ${data.selectedYear} – Reading Weather`,
+		description: 'A photo gallery of weather conditions in Reading and Berkshire, organised by month and year.',
+		url: `https://www.readingweather.co.uk/gallery?year=${data.selectedYear}`
+	});
+
 	const updateYear = (event: Event & { currentTarget: EventTarget & HTMLSelectElement }): void => {
 		const selected = event.currentTarget.value;
 		if (!selected) return;
@@ -56,6 +64,7 @@
 	<meta name="twitter:title" content="Photo Gallery – Reading Weather" />
 	<meta name="twitter:description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
 <h1>Photo Gallery</h1>


### PR DESCRIPTION
## Summary

Today is Thursday — the scheduled category is **Accessibility & SEO**. This PR addresses several screen-reader and Open Graph issues found during a full audit of the codebase.

### Accessibility fixes

- **WeeklyDigest**: temperature arrows (`↑`/`↓`) are now wrapped with `aria-hidden="true"` + a `.sr-only` label (`High:` / `Low:`), matching the pattern already used in `OnThisDay.svelte`. Previously screen readers would announce "up arrow 24 degrees C" with no context.
- **WeekInHistory**: emoji characters (🌡️ ❄️ 🌧️) are wrapped in `aria-hidden` spans so screen readers skip them and read the plain-text label that follows (`Hottest day:`, `Coldest day:`, `Wettest week:`).
- **OnThisDay**: historical post years in the "Forecasts from previous years" list are now rendered as `<time datetime="...">` instead of a plain text span, providing machine-readable date semantics for assistive technologies and search engines.
- **Layout**: the newsletter subscribe `<form>` is now linked to its `<h2>` heading via `aria-labelledby`, giving the form landmark an accessible name.
- **Featured image alt text** (`[slug]` page): the `getPostBySlug` GraphQL query now fetches `altText` from WordPress; this value is used as the `alt` attribute on the post's featured image. For posts where `altText` is empty the behaviour is unchanged (falls back to `""`). `altText?` is added to `GqlPostFeaturedImageNode` in `types.ts`.

### SEO fixes

- **Gallery page**: added JSON-LD `ImageGallery` structured data to `<svelte:head>`, consistent with archives and seasonal-forecasts pages which already have JSON-LD.
- **`[slug]` page — fallback OG image**: `og:image` and `twitter:image` were previously omitted entirely when a post had no featured image. They now fall back to the site default (`/images/weather.png`), matching the pattern used on every other page.
- **`[slug]` page — duplicate `twitter:card`**: removed the redundant `<meta name="twitter:card">` from the slug page; the layout already emits this tag globally, so two identical tags were rendered in the HTML.

## Test plan

- [ ] Check a post page in a screen reader — temperature stats in WeeklyDigest and WeekInHistory should read naturally without emoji/arrow noise
- [ ] Check a post page with no featured image — verify `og:image` is present in the page `<head>` using DevTools
- [ ] Check a post page with a featured image and WordPress alt text set — verify `alt` attribute on the hero image is populated
- [ ] Inspect the gallery page `<head>` to confirm the JSON-LD script tag is present
- [ ] Verify `yarn lint` passes (no errors)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhk3bHYeyRoE6Wnim81FxY)_