### PR TITLE
Add weather streak tracker widget to homepage

### DIFF
--- a/src/lib/api/weatherStreak.spec.ts
+++ b/src/lib/api/weatherStreak.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchWeatherStreak } from './weatherStreak';
+import { fetchWeatherStreak, STREAK_KEY } from './weatherStreak';
 
 // Fixed "now" so the fetch window always ends yesterday, 2026-07-09.
 const NOW = new Date('2026-07-10T12:00:00Z');
@@ -209,6 +209,17 @@ describe('fetchWeatherStreak', () => {
 		const result = await fetchWeatherStreak(NOW);
 		expect(result?.active.type).toBe('dry');
 		expect(result?.active.context).toBe('the longest so far this year');
+	});
+
+	it('describes the dry threshold as under 0.5mm, not zero, so drizzle still counts', () => {
+		const dry = STREAK_KEY.find((k) => k.type === 'dry');
+		expect(dry?.description).toBe(
+			'Under 0.5mm of rain in the day — light drizzle still counts as dry.'
+		);
+	});
+
+	it('exposes a key entry for every streak type', () => {
+		expect(STREAK_KEY.map((k) => k.type)).toEqual(['dry', 'wet', 'warm', 'cold', 'frost', 'sunny']);
 	});
 
 	it('throws when the API request fails', async () => {

--- a/src/lib/api/weatherStreak.spec.ts
+++ b/src/lib/api/weatherStreak.spec.ts
@@ -25,7 +25,8 @@ function makeArchiveResponse(time: string[], overrides: Partial<Record<string, n
 				temperature_2m_max: overrides.temperature_2m_max ?? Array(n).fill(15),
 				temperature_2m_min: overrides.temperature_2m_min ?? Array(n).fill(8),
 				precipitation_sum: overrides.precipitation_sum ?? Array(n).fill(2),
-				sunshine_duration: overrides.sunshine_duration ?? Array(n).fill(0)
+				sunshine_duration: overrides.sunshine_duration ?? Array(n).fill(0),
+				daylight_duration: overrides.daylight_duration ?? Array(n).fill(50000)
 			}
 		})
 	};
@@ -132,6 +133,51 @@ describe('fetchWeatherStreak', () => {
 		const result = await fetchWeatherStreak(NOW);
 		expect(result?.active.type).toBe('dry');
 		expect(result?.active.context).toBe('the longest since 2020');
+	});
+
+	it('judges "sunny" by the share of daylight hours, not an absolute hour count', async () => {
+		const time = dateRange('2026-06-01', '2026-07-09');
+		// Midsummer day length here is ~16h (57600s). A day with 10h of sunshine is
+		// genuinely sunny (63% of daylight); one with 8h is mostly overcast (50%),
+		// even though both would have cleared a naive flat "> 6 hours" threshold.
+		const daylight_duration = time.map(() => 57600);
+		const sunshine_duration = time.map((_, i) => (i === time.length - 2 ? 8 * 3600 : 10 * 3600));
+		// Keep precipitation in the gap between the dry/wet thresholds so those
+		// streaks stay inactive and don't outrank the sunny streak under test.
+		const precipitation_sum = time.map(() => 0.7);
+
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					makeArchiveResponse(time, { sunshine_duration, daylight_duration, precipitation_sum })
+				)
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('sunny');
+		// Streak resets on the overcast day two days ago, so only "yesterday" counts.
+		expect(result?.active.length).toBe(1);
+	});
+
+	it('reports "the longest so far this year" instead of naming the current year', async () => {
+		const time = dateRange('2016-07-10', '2026-07-09');
+		const precipitation_sum = Array(time.length).fill(5);
+		// An earlier 5-day dry spell in March 2026, then the current 5-day streak
+		// ending "yesterday" — both fall within the same year as NOW.
+		const idxMarchStart = time.indexOf('2026-03-01');
+		for (let i = idxMarchStart; i < idxMarchStart + 5; i++) precipitation_sum[i] = 0;
+		for (let i = time.length - 5; i < time.length; i++) precipitation_sum[i] = 0;
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(time, { precipitation_sum }))
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('dry');
+		expect(result?.active.context).toBe('the longest so far this year');
 	});
 
 	it('throws when the API request fails', async () => {

--- a/src/lib/api/weatherStreak.spec.ts
+++ b/src/lib/api/weatherStreak.spec.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchWeatherStreak } from './weatherStreak';
+
+// Fixed "now" so the fetch window always ends yesterday, 2026-07-09.
+const NOW = new Date('2026-07-10T12:00:00Z');
+
+function dateRange(start: string, end: string): string[] {
+	const dates: string[] = [];
+	const d = new Date(`${start}T00:00:00Z`);
+	const endDate = new Date(`${end}T00:00:00Z`);
+	while (d <= endDate) {
+		dates.push(d.toISOString().slice(0, 10));
+		d.setUTCDate(d.getUTCDate() + 1);
+	}
+	return dates;
+}
+
+function makeArchiveResponse(time: string[], overrides: Partial<Record<string, number[]>> = {}) {
+	const n = time.length;
+	return {
+		ok: true,
+		json: async () => ({
+			daily: {
+				time,
+				temperature_2m_max: overrides.temperature_2m_max ?? Array(n).fill(15),
+				temperature_2m_min: overrides.temperature_2m_min ?? Array(n).fill(8),
+				precipitation_sum: overrides.precipitation_sum ?? Array(n).fill(2),
+				sunshine_duration: overrides.sunshine_duration ?? Array(n).fill(0)
+			}
+		})
+	};
+}
+
+describe('fetchWeatherStreak', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('requests a single continuous range ending yesterday, HISTORY_YEARS back', async () => {
+		const time = dateRange('2016-07-10', '2026-07-09');
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse(time)));
+
+		await fetchWeatherStreak(NOW);
+		const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+		const params = new URL(calledUrl).searchParams;
+		expect(params.get('start_date')).toBe('2016-07-09');
+		expect(params.get('end_date')).toBe('2026-07-09');
+	});
+
+	it('detects a current dry streak ending on the last day and reports its length', async () => {
+		const time = dateRange('2026-06-01', '2026-07-09');
+		const precipitation_sum = time.map((_, i) => (i < time.length - 5 ? 5 : 0));
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(time, { precipitation_sum }))
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('dry');
+		expect(result?.active.length).toBe(5);
+	});
+
+	it('returns null when no streak is currently active', async () => {
+		const time = dateRange('2026-06-01', '2026-07-09');
+		// The final day (index length-1, i.e. "yesterday") sits in the gap between the
+		// dry and wet thresholds and is otherwise unremarkable, so no run reaches it.
+		const precipitation_sum = time.map((_, i) => (i === time.length - 1 ? 0.7 : 5));
+		const temperature_2m_max = time.map((_, i) => (i === time.length - 1 ? 10 : 15));
+		const temperature_2m_min = time.map((_, i) => (i === time.length - 1 ? 3 : 8));
+		const sunshine_duration = time.map(() => 0);
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					makeArchiveResponse(time, {
+						precipitation_sum,
+						temperature_2m_max,
+						temperature_2m_min,
+						sunshine_duration
+					})
+				)
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result).toBeNull();
+	});
+
+	it('picks the longest active streak as the primary and lists the rest as secondary', async () => {
+		const time = dateRange('2026-06-01', '2026-07-09');
+		// Last 3 days are dry AND frosty; make the dry streak longer by starting it earlier.
+		const precipitation_sum = time.map((_, i) => (i < time.length - 6 ? 5 : 0));
+		const temperature_2m_min = time.map((_, i) => (i < time.length - 3 ? 8 : -1));
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(makeArchiveResponse(time, { precipitation_sum, temperature_2m_min }))
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('dry');
+		expect(result?.active.length).toBe(6);
+		expect(result?.secondary.some((s) => s.type === 'frost')).toBe(true);
+	});
+
+	it('reports "the longest in at least N years" when nothing that long occurred before', async () => {
+		const time = dateRange('2016-07-10', '2026-07-09');
+		const precipitation_sum = time.map((_, i) => (i < time.length - 10 ? 5 : 0));
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(time, { precipitation_sum }))
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.context).toBe('the longest in at least 10 years of records');
+	});
+
+	it('reports "the longest since <year>" when an earlier equal-or-longer streak is found', async () => {
+		const time = dateRange('2016-07-10', '2026-07-09');
+		const precipitation_sum = Array(time.length).fill(5);
+		// A long dry spell in 2020, then the current 4-day streak ending "yesterday".
+		const idx2020Start = time.indexOf('2020-08-01');
+		for (let i = idx2020Start; i < idx2020Start + 8; i++) precipitation_sum[i] = 0;
+		for (let i = time.length - 4; i < time.length; i++) precipitation_sum[i] = 0;
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(time, { precipitation_sum }))
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('dry');
+		expect(result?.active.context).toBe('the longest since 2020');
+	});
+
+	it('throws when the API request fails', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+		await expect(fetchWeatherStreak(NOW)).rejects.toThrow('Open-Meteo error: 500');
+	});
+});

--- a/src/lib/api/weatherStreak.spec.ts
+++ b/src/lib/api/weatherStreak.spec.ts
@@ -161,6 +161,37 @@ describe('fetchWeatherStreak', () => {
 		expect(result?.active.length).toBe(1);
 	});
 
+	it('reports the sunny threshold in absolute hours for the current month', async () => {
+		const time = dateRange('2026-06-01', '2026-07-09');
+		const daylight_duration = time.map(() => 16 * 3600);
+		const sunshine_duration = time.map(() => 15 * 3600);
+		const precipitation_sum = time.map(() => 0.7);
+
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					makeArchiveResponse(time, { sunshine_duration, daylight_duration, precipitation_sum })
+				)
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('sunny');
+		// SUNNY_RATIO (0.6) of a 16-hour daylight day, in the month of the last data point (July).
+		expect(result?.active.definition).toBe(
+			'Counted as sunny if it gets more than 10 hours of sunshine here in July (~16 hours of daylight this time of year)'
+		);
+	});
+
+	it('reports the date the streak was last measured through', async () => {
+		const time = dateRange('2026-06-01', '2026-07-09');
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse(time)));
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.asOf).toBe('9 July 2026');
+	});
+
 	it('reports "the longest so far this year" instead of naming the current year', async () => {
 		const time = dateRange('2016-07-10', '2026-07-09');
 		const precipitation_sum = Array(time.length).fill(5);

--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -34,11 +34,21 @@ type DayMetrics = {
 
 type StreakType = 'dry' | 'wet' | 'warm' | 'cold' | 'frost' | 'sunny';
 
+// A day counts as "sunny" once it clears this share of that day's daylight
+// hours — see the note on `sunshineRatio` above for why this has to scale
+// with the season rather than being a flat number of hours.
+const SUNNY_RATIO = 0.6;
+
 type StreakDefinition = {
 	type: StreakType;
 	emoji: string;
 	label: (n: number) => string;
 	test: (day: DayMetrics) => boolean;
+	// Explains the threshold in absolute, human terms for the current time of
+	// year (e.g. "needs more than 10 hours of sunshine in July"), since the
+	// underlying rule for `sunny` is a ratio the reader can't sanity-check
+	// on its own.
+	buildDefinition?: (daylightHours: number, monthName: string) => string;
 };
 
 const STREAK_DEFINITIONS: StreakDefinition[] = [
@@ -76,7 +86,9 @@ const STREAK_DEFINITIONS: StreakDefinition[] = [
 		type: 'sunny',
 		emoji: '🌞',
 		label: (n) => `${n} sunny day${n === 1 ? '' : 's'} in a row in Reading`,
-		test: (d) => d.sunshineRatio > 0.6
+		test: (d) => d.sunshineRatio > SUNNY_RATIO,
+		buildDefinition: (daylightHours, monthName) =>
+			`Counted as sunny if it gets more than ${Math.round(daylightHours * SUNNY_RATIO)} hours of sunshine here in ${monthName} (~${Math.round(daylightHours)} hours of daylight this time of year)`
 	}
 ];
 
@@ -86,11 +98,15 @@ export type Streak = {
 	length: number;
 	headline: string;
 	context: string;
+	definition?: string;
 };
 
 export type WeatherStreakResult = {
 	active: Streak;
 	secondary: Streak[];
+	// The last complete day the streak was measured through, e.g. "9 July 2026" —
+	// without this, "the longest since 2023" has no visible anchor for what "now" means.
+	asOf: string;
 };
 
 type Run = { startIndex: number; endIndex: number; length: number };
@@ -169,7 +185,13 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 	}));
 
 	const currentYear = end.getUTCFullYear();
-	const candidates: { def: StreakDefinition; length: number; context: string }[] = [];
+	const lastDayDaylightHours = daylight_duration[daylight_duration.length - 1] / 3600;
+	const lastDayMonthName = new Date(time[time.length - 1]).toLocaleString('en-GB', {
+		month: 'long',
+		timeZone: 'UTC'
+	});
+
+	const candidates: { def: StreakDefinition; length: number; context: string; definition?: string }[] = [];
 
 	for (const def of STREAK_DEFINITIONS) {
 		const matches = days.map((d) => def.test(d));
@@ -183,7 +205,8 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 		candidates.push({
 			def,
 			length: lastRun.length,
-			context: buildContext(lastRun.length, priorRuns, time, currentYear)
+			context: buildContext(lastRun.length, priorRuns, time, currentYear),
+			definition: def.buildDefinition?.(lastDayDaylightHours, lastDayMonthName)
 		});
 	}
 
@@ -196,12 +219,21 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 		emoji: c.def.emoji,
 		length: c.length,
 		headline: c.def.label(c.length),
-		context: c.context
+		context: c.context,
+		definition: c.definition
+	});
+
+	const asOf = new Date(time[time.length - 1]).toLocaleDateString('en-GB', {
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+		timeZone: 'UTC'
 	});
 
 	const [primary, ...rest] = candidates;
 	return {
 		active: toStreak(primary),
-		secondary: rest.slice(0, 2).map(toStreak)
+		secondary: rest.slice(0, 2).map(toStreak),
+		asOf
 	};
 }

--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -1,0 +1,190 @@
+const READING_LAT = 51.4543;
+const READING_LON = -0.9781;
+
+// How far back we look for a comparable historical streak of the same length.
+const HISTORY_YEARS = 10;
+
+// A single continuous-range request covering ten years takes a few seconds to
+// generate upstream, so give it more headroom than a single-day fetch.
+const REQUEST_TIMEOUT_MS = 15000;
+
+type OpenMeteoArchiveResponse = {
+	daily: {
+		time: string[];
+		temperature_2m_max: number[];
+		temperature_2m_min: number[];
+		precipitation_sum: number[];
+		sunshine_duration: number[];
+	};
+};
+
+type DayMetrics = {
+	tempMax: number;
+	tempMin: number;
+	precipitation: number;
+	sunshineHours: number;
+};
+
+type StreakType = 'dry' | 'wet' | 'warm' | 'cold' | 'frost' | 'sunny';
+
+type StreakDefinition = {
+	type: StreakType;
+	emoji: string;
+	label: (n: number) => string;
+	test: (day: DayMetrics) => boolean;
+};
+
+const STREAK_DEFINITIONS: StreakDefinition[] = [
+	{
+		type: 'dry',
+		emoji: '☀️',
+		label: (n) => `${n} consecutive dry day${n === 1 ? '' : 's'} in Reading`,
+		test: (d) => d.precipitation < 0.5
+	},
+	{
+		type: 'wet',
+		emoji: '🌧️',
+		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} of rain in Reading`,
+		test: (d) => d.precipitation >= 1
+	},
+	{
+		type: 'warm',
+		emoji: '🔥',
+		label: (n) => `${n} day${n === 1 ? '' : 's'} above 25°C in Reading`,
+		test: (d) => d.tempMax >= 25
+	},
+	{
+		type: 'cold',
+		emoji: '🥶',
+		label: (n) => `${n} day${n === 1 ? '' : 's'} below 5°C in Reading`,
+		test: (d) => d.tempMax < 5
+	},
+	{
+		type: 'frost',
+		emoji: '❄️',
+		label: (n) => `${n} consecutive night${n === 1 ? '' : 's'} of frost in Reading`,
+		test: (d) => d.tempMin < 0
+	},
+	{
+		type: 'sunny',
+		emoji: '🌞',
+		label: (n) => `${n} sunny day${n === 1 ? '' : 's'} in a row in Reading`,
+		test: (d) => d.sunshineHours > 6
+	}
+];
+
+export type Streak = {
+	type: StreakType;
+	emoji: string;
+	length: number;
+	headline: string;
+	context: string;
+};
+
+export type WeatherStreakResult = {
+	active: Streak;
+	secondary: Streak[];
+};
+
+type Run = { startIndex: number; endIndex: number; length: number };
+
+function toDateStr(date: Date): string {
+	return date.toISOString().slice(0, 10);
+}
+
+function findRuns(matches: boolean[]): Run[] {
+	const runs: Run[] = [];
+	let runStart = -1;
+	for (let i = 0; i < matches.length; i++) {
+		if (matches[i]) {
+			if (runStart === -1) runStart = i;
+		} else if (runStart !== -1) {
+			runs.push({ startIndex: runStart, endIndex: i - 1, length: i - runStart });
+			runStart = -1;
+		}
+	}
+	if (runStart !== -1) {
+		runs.push({ startIndex: runStart, endIndex: matches.length - 1, length: matches.length - runStart });
+	}
+	return runs;
+}
+
+function buildContext(currentLength: number, priorRuns: Run[], dates: string[]): string {
+	const atLeastAsLong = priorRuns
+		.filter((r) => r.length >= currentLength)
+		.sort((a, b) => b.endIndex - a.endIndex);
+
+	if (atLeastAsLong.length === 0) {
+		return `the longest in at least ${HISTORY_YEARS} years of records`;
+	}
+
+	const year = new Date(dates[atLeastAsLong[0].endIndex]).getUTCFullYear();
+	return `the longest since ${year}`;
+}
+
+export async function fetchWeatherStreak(now: Date = new Date()): Promise<WeatherStreakResult | null> {
+	const end = new Date(now);
+	end.setUTCDate(end.getUTCDate() - 1);
+	const start = new Date(end);
+	start.setUTCFullYear(start.getUTCFullYear() - HISTORY_YEARS);
+
+	const params = new URLSearchParams({
+		latitude: String(READING_LAT),
+		longitude: String(READING_LON),
+		start_date: toDateStr(start),
+		end_date: toDateStr(end),
+		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,sunshine_duration',
+		timezone: 'Europe/London'
+	});
+
+	const response = await fetch(`https://archive-api.open-meteo.com/v1/archive?${params}`, {
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+	});
+	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
+
+	const data = (await response.json()) as OpenMeteoArchiveResponse;
+	const { time, temperature_2m_max, temperature_2m_min, precipitation_sum, sunshine_duration } = data.daily;
+
+	const days: DayMetrics[] = time.map((_, i) => ({
+		tempMax: temperature_2m_max[i],
+		tempMin: temperature_2m_min[i],
+		precipitation: precipitation_sum[i],
+		sunshineHours: sunshine_duration[i] / 3600
+	}));
+
+	const candidates: { def: StreakDefinition; length: number; context: string }[] = [];
+
+	for (const def of STREAK_DEFINITIONS) {
+		const matches = days.map((d) => def.test(d));
+		const runs = findRuns(matches);
+		if (runs.length === 0) continue;
+
+		const lastRun = runs[runs.length - 1];
+		if (lastRun.endIndex !== matches.length - 1) continue;
+
+		const priorRuns = runs.slice(0, -1);
+		candidates.push({
+			def,
+			length: lastRun.length,
+			context: buildContext(lastRun.length, priorRuns, time)
+		});
+	}
+
+	if (candidates.length === 0) return null;
+
+	candidates.sort((a, b) => b.length - a.length);
+
+	const toStreak = (c: (typeof candidates)[number]): Streak => ({
+		type: c.def.type,
+		emoji: c.def.emoji,
+		length: c.length,
+		headline: c.def.label(c.length),
+		context: c.context
+	});
+
+	const [primary, ...rest] = candidates;
+	return {
+		active: toStreak(primary),
+		secondary: rest.slice(0, 2).map(toStreak)
+	};
+}

--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -44,6 +44,9 @@ type StreakDefinition = {
 	emoji: string;
 	label: (n: number) => string;
 	test: (day: DayMetrics) => boolean;
+	// A fixed, plain-English statement of the threshold, for a "what counts as X"
+	// key — e.g. so a reader doesn't assume a bit of drizzle rules out a dry day.
+	description: string;
 	// Explains the threshold in absolute, human terms for the current time of
 	// year (e.g. "needs more than 10 hours of sunshine in July"), since the
 	// underlying rule for `sunny` is a ratio the reader can't sanity-check
@@ -56,41 +59,51 @@ const STREAK_DEFINITIONS: StreakDefinition[] = [
 		type: 'dry',
 		emoji: '☀️',
 		label: (n) => `${n} consecutive dry day${n === 1 ? '' : 's'} in Reading`,
-		test: (d) => d.precipitation < 0.5
+		test: (d) => d.precipitation < 0.5,
+		description: 'Under 0.5mm of rain in the day — light drizzle still counts as dry.'
 	},
 	{
 		type: 'wet',
 		emoji: '🌧️',
 		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} of rain in Reading`,
-		test: (d) => d.precipitation >= 1
+		test: (d) => d.precipitation >= 1,
+		description: '1mm of rain or more in the day.'
 	},
 	{
 		type: 'warm',
 		emoji: '🔥',
-		label: (n) => `${n} day${n === 1 ? '' : 's'} above 25°C in Reading`,
-		test: (d) => d.tempMax >= 25
+		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} above 25°C in Reading`,
+		test: (d) => d.tempMax >= 25,
+		description: 'A high of 25°C or above.'
 	},
 	{
 		type: 'cold',
 		emoji: '🥶',
-		label: (n) => `${n} day${n === 1 ? '' : 's'} below 5°C in Reading`,
-		test: (d) => d.tempMax < 5
+		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} below 5°C in Reading`,
+		test: (d) => d.tempMax < 5,
+		description: "A high that never climbs above 5°C — it stays cold all day."
 	},
 	{
 		type: 'frost',
 		emoji: '❄️',
 		label: (n) => `${n} consecutive night${n === 1 ? '' : 's'} of frost in Reading`,
-		test: (d) => d.tempMin < 0
+		test: (d) => d.tempMin < 0,
+		description: 'An overnight low below 0°C.'
 	},
 	{
 		type: 'sunny',
 		emoji: '🌞',
 		label: (n) => `${n} sunny day${n === 1 ? '' : 's'} in a row in Reading`,
 		test: (d) => d.sunshineRatio > SUNNY_RATIO,
+		description:
+			'More than 60% of that day’s daylight hours have genuine sunshine — the equivalent hour count varies by season and is shown alongside the streak.',
 		buildDefinition: (daylightHours, monthName) =>
 			`Counted as sunny if it gets more than ${Math.round(daylightHours * SUNNY_RATIO)} hours of sunshine here in ${monthName} (~${Math.round(daylightHours)} hours of daylight this time of year)`
 	}
 ];
+
+export const STREAK_KEY: { type: StreakType; emoji: string; description: string }[] =
+	STREAK_DEFINITIONS.map(({ type, emoji, description }) => ({ type, emoji, description }));
 
 export type Streak = {
 	type: StreakType;

--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -15,6 +15,7 @@ type OpenMeteoArchiveResponse = {
 		temperature_2m_min: number[];
 		precipitation_sum: number[];
 		sunshine_duration: number[];
+		daylight_duration: number[];
 	};
 };
 
@@ -22,7 +23,13 @@ type DayMetrics = {
 	tempMax: number;
 	tempMin: number;
 	precipitation: number;
-	sunshineHours: number;
+	// Fraction of daylight hours that saw genuine sunshine (irradiance above the
+	// WMO threshold). A flat hour count is useless here: Reading's midsummer days
+	// are ~16.5h long, so "sunshine_duration > 6h" was true on almost every day of
+	// the year regardless of actual cloud cover, including a 19.4mm rain day. The
+	// ratio to daylight length is what actually distinguishes a sunny day from an
+	// overcast one, in any season.
+	sunshineRatio: number;
 };
 
 type StreakType = 'dry' | 'wet' | 'warm' | 'cold' | 'frost' | 'sunny';
@@ -69,7 +76,7 @@ const STREAK_DEFINITIONS: StreakDefinition[] = [
 		type: 'sunny',
 		emoji: '🌞',
 		label: (n) => `${n} sunny day${n === 1 ? '' : 's'} in a row in Reading`,
-		test: (d) => d.sunshineHours > 6
+		test: (d) => d.sunshineRatio > 0.6
 	}
 ];
 
@@ -109,7 +116,7 @@ function findRuns(matches: boolean[]): Run[] {
 	return runs;
 }
 
-function buildContext(currentLength: number, priorRuns: Run[], dates: string[]): string {
+function buildContext(currentLength: number, priorRuns: Run[], dates: string[], currentYear: number): string {
 	const atLeastAsLong = priorRuns
 		.filter((r) => r.length >= currentLength)
 		.sort((a, b) => b.endIndex - a.endIndex);
@@ -119,7 +126,9 @@ function buildContext(currentLength: number, priorRuns: Run[], dates: string[]):
 	}
 
 	const year = new Date(dates[atLeastAsLong[0].endIndex]).getUTCFullYear();
-	return `the longest since ${year}`;
+	// A match found earlier in the same year isn't a meaningful "since <year>" —
+	// that phrasing only makes sense pointing back at a previous year.
+	return year === currentYear ? 'the longest so far this year' : `the longest since ${year}`;
 }
 
 export async function fetchWeatherStreak(now: Date = new Date()): Promise<WeatherStreakResult | null> {
@@ -133,7 +142,7 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 		longitude: String(READING_LON),
 		start_date: toDateStr(start),
 		end_date: toDateStr(end),
-		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,sunshine_duration',
+		daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,sunshine_duration,daylight_duration',
 		timezone: 'Europe/London'
 	});
 
@@ -143,15 +152,23 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
 
 	const data = (await response.json()) as OpenMeteoArchiveResponse;
-	const { time, temperature_2m_max, temperature_2m_min, precipitation_sum, sunshine_duration } = data.daily;
+	const {
+		time,
+		temperature_2m_max,
+		temperature_2m_min,
+		precipitation_sum,
+		sunshine_duration,
+		daylight_duration
+	} = data.daily;
 
 	const days: DayMetrics[] = time.map((_, i) => ({
 		tempMax: temperature_2m_max[i],
 		tempMin: temperature_2m_min[i],
 		precipitation: precipitation_sum[i],
-		sunshineHours: sunshine_duration[i] / 3600
+		sunshineRatio: sunshine_duration[i] / daylight_duration[i]
 	}));
 
+	const currentYear = end.getUTCFullYear();
 	const candidates: { def: StreakDefinition; length: number; context: string }[] = [];
 
 	for (const def of STREAK_DEFINITIONS) {
@@ -166,7 +183,7 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 		candidates.push({
 			def,
 			length: lastRun.length,
-			context: buildContext(lastRun.length, priorRuns, time)
+			context: buildContext(lastRun.length, priorRuns, time, currentYear)
 		});
 	}
 

--- a/src/lib/components/WeatherStreak.svelte
+++ b/src/lib/components/WeatherStreak.svelte
@@ -21,16 +21,23 @@
 			<strong>{streak.active.headline}</strong>
 			— {streak.active.context}
 		</p>
+		{#if streak.active.definition}
+			<p class="definition">{streak.active.definition}</p>
+		{/if}
 		{#if streak.secondary.length > 0}
 			<ul class="secondary">
 				{#each streak.secondary as s}
-					<li><span aria-hidden="true">{s.emoji}</span> {s.headline}</li>
+					<li>
+						<span aria-hidden="true">{s.emoji}</span>
+						{s.headline} — {s.context}
+						{#if s.definition}<span class="definition"> ({s.definition})</span>{/if}
+					</li>
 				{/each}
 			</ul>
 		{/if}
 		<p class="conditions-note">
-			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
-			approximate guide only.
+			Streak measured through {streak.asOf}. Weather conditions are sourced from ERA5
+			reanalysis data and should be treated as an approximate guide only.
 		</p>
 	</section>
 {/if}

--- a/src/lib/components/WeatherStreak.svelte
+++ b/src/lib/components/WeatherStreak.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { WeatherStreakResult } from '$lib/api/weatherStreak';
+
+	let streak = $state<WeatherStreakResult | null>(null);
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/api/weather-streak');
+			if (res.ok) streak = (await res.json()) as WeatherStreakResult | null;
+		} catch {
+			// silently fail — weather data is supplementary
+		}
+	});
+</script>
+
+{#if streak}
+	<section class="weather-streak">
+		<p class="headline">
+			<span aria-hidden="true">{streak.active.emoji}</span>
+			<strong>{streak.active.headline}</strong>
+			— {streak.active.context}
+		</p>
+		{#if streak.secondary.length > 0}
+			<ul class="secondary">
+				{#each streak.secondary as s}
+					<li><span aria-hidden="true">{s.emoji}</span> {s.headline}</li>
+				{/each}
+			</ul>
+		{/if}
+		<p class="conditions-note">
+			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
+			approximate guide only.
+		</p>
+	</section>
+{/if}

--- a/src/lib/components/WeatherStreak.svelte
+++ b/src/lib/components/WeatherStreak.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import type { WeatherStreakResult } from '$lib/api/weatherStreak';
+	import { STREAK_KEY, type WeatherStreakResult } from '$lib/api/weatherStreak';
 
 	let streak = $state<WeatherStreakResult | null>(null);
 
@@ -16,6 +16,7 @@
 
 {#if streak}
 	<section class="weather-streak">
+		<h2>Reading Weather Streak Tracker</h2>
 		<p class="headline">
 			<span aria-hidden="true">{streak.active.emoji}</span>
 			<strong>{streak.active.headline}</strong>
@@ -35,6 +36,14 @@
 				{/each}
 			</ul>
 		{/if}
+		<details class="streak-key">
+			<summary>What counts as a streak?</summary>
+			<ul>
+				{#each STREAK_KEY as k}
+					<li><span aria-hidden="true">{k.emoji}</span> <strong>{k.type}</strong> — {k.description}</li>
+				{/each}
+			</ul>
+		</details>
 		<p class="conditions-note">
 			Streak measured through {streak.asOf}. Weather conditions are sourced from ERA5
 			reanalysis data and should be treated as an approximate guide only.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import '../styles/index.css';
 	import OnThisDay from '$lib/components/OnThisDay.svelte';
 	import PostList from '$lib/components/PostList.svelte';
+	import WeatherStreak from '$lib/components/WeatherStreak.svelte';
 	import WeekInHistory from '$lib/components/WeekInHistory.svelte';
 	import WeeklyDigest from '$lib/components/WeeklyDigest.svelte';
 
@@ -40,6 +41,8 @@
 		<a href="/{data.latestSeasonalPost.slug}">{data.latestSeasonalPost.title}</a>
 	</section>
 {/if}
+
+<WeatherStreak />
 
 {#if data.onThisDay?.posts?.nodes?.length}
 	<OnThisDay posts={data.onThisDay.posts.nodes} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,17 +42,17 @@
 	</section>
 {/if}
 
-<WeatherStreak />
-
 {#if data.onThisDay?.posts?.nodes?.length}
 	<OnThisDay posts={data.onThisDay.posts.nodes} />
 {/if}
+
+<WeeklyDigest />
+
+<WeekInHistory />
+
+<WeatherStreak />
 
 <div class="older-posts">
 	<p>Looking for older posts?</p>
 	<a href="/archives">Check out the archives</a>
 </div>
-
-<WeeklyDigest />
-
-<WeekInHistory />

--- a/src/routes/api/weather-streak/+server.ts
+++ b/src/routes/api/weather-streak/+server.ts
@@ -1,0 +1,31 @@
+import { json } from '@sveltejs/kit';
+import { fetchWeatherStreak, type WeatherStreakResult } from '$lib/api/weatherStreak';
+import { getCache, setCache } from '$lib/server/cache';
+import type { RequestHandler } from './$types';
+
+const TTL_MS = 12 * 60 * 60 * 1000;
+const ERROR_TTL_MS = 5 * 60 * 1000;
+
+type CachedStreak = { result: WeatherStreakResult | null };
+
+export const GET: RequestHandler = async () => {
+	const cacheKey = `weather-streak-${new Date().toISOString().slice(0, 10)}`;
+	const cached = getCache<CachedStreak>(cacheKey);
+	if (cached) return json(cached.result);
+
+	const errorCacheKey = `${cacheKey}-error`;
+	if (getCache<true>(errorCacheKey)) {
+		return json({ error: 'Weather streak temporarily unavailable' }, { status: 502 });
+	}
+
+	try {
+		const data = await fetchWeatherStreak();
+		setCache<CachedStreak>(cacheKey, { result: data }, TTL_MS);
+		return json(data);
+	} catch (err) {
+		// Avoid hammering an already-failing/rate-limited upstream on every request.
+		setCache(errorCacheKey, true, ERROR_TTL_MS);
+		console.error('fetchWeatherStreak failed:', err);
+		return json({ error: 'Weather streak temporarily unavailable' }, { status: 502 });
+	}
+};

--- a/src/routes/api/weather-streak/server.spec.ts
+++ b/src/routes/api/weather-streak/server.spec.ts
@@ -18,7 +18,8 @@ const mockStreak: WeatherStreakResult = {
 		headline: '14 consecutive dry days in Reading',
 		context: 'the longest since 2022'
 	},
-	secondary: []
+	secondary: [],
+	asOf: '9 July 2026'
 };
 
 vi.mock('$lib/api/weatherStreak', () => ({

--- a/src/routes/api/weather-streak/server.spec.ts
+++ b/src/routes/api/weather-streak/server.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WeatherStreakResult } from '$lib/api/weatherStreak';
+
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn((key: string) => cacheStore.get(key) ?? null),
+	setCache: vi.fn((key: string, data: unknown) => {
+		cacheStore.set(key, data);
+	})
+}));
+
+const mockStreak: WeatherStreakResult = {
+	active: {
+		type: 'dry',
+		emoji: '☀️',
+		length: 14,
+		headline: '14 consecutive dry days in Reading',
+		context: 'the longest since 2022'
+	},
+	secondary: []
+};
+
+vi.mock('$lib/api/weatherStreak', () => ({
+	fetchWeatherStreak: vi.fn()
+}));
+
+import { fetchWeatherStreak } from '$lib/api/weatherStreak';
+import { GET } from './+server';
+
+beforeEach(() => {
+	cacheStore.clear();
+	vi.clearAllMocks();
+});
+
+describe('GET /api/weather-streak', () => {
+	it('returns 200 with the streak data', async () => {
+		vi.mocked(fetchWeatherStreak).mockResolvedValue(mockStreak);
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.active.headline).toBe('14 consecutive dry days in Reading');
+	});
+
+	it('returns 200 with null when no streak is currently active', async () => {
+		vi.mocked(fetchWeatherStreak).mockResolvedValue(null);
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toBeNull();
+	});
+
+	it('returns a 502 with an error body when the upstream fetch fails', async () => {
+		vi.mocked(fetchWeatherStreak).mockRejectedValue(new Error('Open-Meteo error: 429'));
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(502);
+		const body = await response.json();
+		expect(body.error).toBeTruthy();
+	});
+
+	it('does not call the upstream again while a recent failure is cached', async () => {
+		vi.mocked(fetchWeatherStreak).mockRejectedValue(new Error('Open-Meteo error: 429'));
+		await GET({} as Parameters<typeof GET>[0]);
+
+		vi.mocked(fetchWeatherStreak).mockClear();
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(502);
+		expect(fetchWeatherStreak).not.toHaveBeenCalled();
+	});
+
+	it('does not call the upstream again once a null result is cached', async () => {
+		vi.mocked(fetchWeatherStreak).mockResolvedValue(null);
+		await GET({} as Parameters<typeof GET>[0]);
+
+		vi.mocked(fetchWeatherStreak).mockClear();
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toBeNull();
+		expect(fetchWeatherStreak).not.toHaveBeenCalled();
+	});
+});

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -210,6 +210,11 @@ main {
 	text-align: center;
 	background: var(--white);
 
+	/* biome-ignore lint/style/noDescendingSpecificity: targets .weather-streak h2, unrelated to main .post h2 */
+	h2 {
+		margin: 0 0 0.75rem;
+	}
+
 	.headline {
 		margin: 0 0 0.5rem;
 		font-size: 1.1rem;
@@ -230,6 +235,28 @@ main {
 		font-size: 0.8rem;
 		color: #767676;
 		margin: 0 0 0.5rem;
+	}
+
+	.streak-key {
+		text-align: left;
+		font-size: 0.85rem;
+		color: #555;
+		margin: 0.5rem 0 0;
+
+		summary {
+			cursor: pointer;
+			text-align: center;
+			color: var(--nav);
+		}
+
+		ul {
+			list-style: none;
+			padding: 0;
+			margin: 0.5rem 0 0;
+			display: flex;
+			flex-direction: column;
+			gap: 0.3rem;
+		}
 	}
 
 	.conditions-note {
@@ -261,6 +288,7 @@ main {
 	margin: 2rem;
 	flex-direction: column;
 
+	/* biome-ignore lint/style/noDescendingSpecificity: targets .archive-container ul, unrelated to .streak-key ul */
 	ul {
 		list-style: none;
 		padding: 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -203,6 +203,37 @@ main {
 	}
 }
 
+.weather-streak {
+	border: 5px solid var(--nav);
+	margin-bottom: 2rem;
+	padding: 1rem;
+	text-align: center;
+	background: var(--white);
+
+	.headline {
+		margin: 0 0 0.5rem;
+		font-size: 1.1rem;
+	}
+
+	.secondary {
+		list-style: none;
+		padding: 0;
+		margin: 0 0 0.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		font-size: 0.95rem;
+		color: #555;
+	}
+
+	.conditions-note {
+		font-size: 0.8rem;
+		color: #767676;
+		margin: 0.75rem 0 0;
+		font-style: italic;
+	}
+}
+
 .older-posts {
 	text-align: center;
 	margin: 0 0 2rem 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -226,6 +226,12 @@ main {
 		color: #555;
 	}
 
+	.definition {
+		font-size: 0.8rem;
+		color: #767676;
+		margin: 0 0 0.5rem;
+	}
+
 	.conditions-note {
 		font-size: 0.8rem;
 		color: #767676;


### PR DESCRIPTION
## Summary
- Adds a **Weather Streak Tracker** widget to the homepage (between the latest seasonal forecast and "On This Day"), per #379
- `src/lib/api/weatherStreak.ts` fetches 10 years of daily Reading weather from the Open-Meteo archive API and detects the currently active dry / wet / warm / cold / frost / sunny streak, picking the most notable one and giving it "the longest since `<year>`" (or "longest in at least N years of records") context, with up to two secondary streaks shown alongside
- New cached `/api/weather-streak` endpoint (12h TTL, 5min error-cache) follows the same pattern as `/api/week-in-history`
- `WeatherStreak.svelte` client-fetches and renders the widget, degrading silently if the upstream API is unavailable (same pattern as `OnThisDay`/`WeekInHistory`)
- Styles added to `src/styles/index.css` (no component `<style>` blocks) matching the existing `.week-in-history` look

## Test plan
- [x] `yarn ts-check` — no errors
- [x] `yarn lint` — clean
- [x] `yarn test:unit` — 129 tests passing, including new unit tests for streak detection/context logic and the API route's caching behaviour
- [x] `yarn build` succeeds
- [x] Manually hit `/api/weather-streak` against the live Open-Meteo API and confirmed real data comes back correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)