### PR TITLE
chore(typescript): extract shared utility, add return types, narrow sitemap type

### DIFF
--- a/src/lib/api/historicalWeather.ts
+++ b/src/lib/api/historicalWeather.ts
@@ -100,7 +100,7 @@ async function fetchOneDay(dateStr: string): Promise<DailyWeather> {
 
 export async function fetchHistoricalWeather(month: number, day: number): Promise<DailyWeather[]> {
 	const currentYear = new Date().getFullYear();
-	const pad = (n: number) => String(n).padStart(2, '0');
+	const pad = (n: number): string => String(n).padStart(2, '0');
 	const mmdd = `${pad(month)}-${pad(day)}`;
 
 	const years = Array.from({ length: 6 }, (_, i) => currentYear - 6 + i);

--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -1,3 +1,5 @@
+import { toDateStr } from '$lib/dateUtils';
+
 const READING_LAT = 51.4543;
 const READING_LON = -0.9781;
 
@@ -123,10 +125,6 @@ export type WeatherStreakResult = {
 };
 
 type Run = { startIndex: number; endIndex: number; length: number };
-
-function toDateStr(date: Date): string {
-	return date.toISOString().slice(0, 10);
-}
 
 function findRuns(matches: boolean[]): Run[] {
 	const runs: Run[] = [];

--- a/src/lib/api/weekInHistory.ts
+++ b/src/lib/api/weekInHistory.ts
@@ -1,3 +1,5 @@
+import { toDateStr } from '$lib/dateUtils';
+
 const READING_LAT = 51.4543;
 const READING_LON = -0.9781;
 
@@ -30,10 +32,6 @@ export type WeekInHistory = {
 	coldestDay: YearRecord;
 	wettestWeek: YearRecord;
 };
-
-function toDateStr(date: Date): string {
-	return date.toISOString().slice(0, 10);
-}
 
 function sameWindowInYear(start: Date, end: Date, year: number): { start: Date; end: Date } {
 	const yearStart = new Date(Date.UTC(year, start.getUTCMonth(), start.getUTCDate()));

--- a/src/lib/api/weeklyDigest.ts
+++ b/src/lib/api/weeklyDigest.ts
@@ -1,3 +1,5 @@
+import { toDateStr } from '$lib/dateUtils';
+
 const READING_LAT = 51.4543;
 const READING_LON = -0.9781;
 
@@ -76,10 +78,6 @@ export type WeeklyDigest = {
 	cloudiestDay: DaySummary;
 	dominantConditions: string;
 };
-
-function toDateStr(date: Date): string {
-	return date.toISOString().slice(0, 10);
-}
 
 export async function fetchWeeklyDigest(now: Date = new Date()): Promise<WeeklyDigest> {
 	const end = new Date(now);

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -3,7 +3,12 @@
 	import { sanitize } from '$lib/sanitize';
 	import type { AllPostsNode } from '$lib/types';
 
-	const { posts, preview = false }: { posts: AllPostsNode[]; preview?: boolean } = $props();
+	type Props = {
+		posts: AllPostsNode[];
+		preview?: boolean;
+	};
+
+	const { posts, preview = false }: Props = $props();
 
 	const firstParagraph = (content: string): string => {
 		const first = content.split(/<\/?p>/).find((p) => p.trim() !== '');

--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-	const {
-		postUrl,
-		postTitle,
-		postSummary
-	}: { postUrl: string; postTitle: string; postSummary: string } = $props();
+	type Props = {
+		postUrl: string;
+		postTitle: string;
+		postSummary: string;
+	};
+
+	const { postUrl, postTitle, postSummary }: Props = $props();
 
 	let copied = $state(false);
 

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,4 @@
+/** Formats a Date as YYYY-MM-DD in UTC. */
+export function toDateStr(date: Date): string {
+	return date.toISOString().slice(0, 10);
+}

--- a/src/lib/server/sitemap.ts
+++ b/src/lib/server/sitemap.ts
@@ -16,7 +16,9 @@ const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 export type SitemapNode = { slug: string; date: string | null };
 
-export type StaticRoute = { path: string; changefreq: string; priority: string };
+export type SitemapChangefreq = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+
+export type StaticRoute = { path: string; changefreq: SitemapChangefreq; priority: string };
 
 function escapeXml(value: string): string {
 	return value
@@ -27,7 +29,7 @@ function escapeXml(value: string): string {
 		.replace(/'/g, '&apos;');
 }
 
-function toXmlUrl(loc: string, lastmod?: string, changefreq = 'monthly', priority = '0.7'): string {
+function toXmlUrl(loc: string, lastmod?: string, changefreq: SitemapChangefreq = 'monthly', priority = '0.7'): string {
 	const last = lastmod ? `<lastmod>${escapeXml(lastmod)}</lastmod>` : '';
 	return `
     <url>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -29,17 +29,17 @@
 	let lightboxDialog = $state<HTMLDialogElement | null>(null);
 	let triggerButton = $state<HTMLButtonElement | null>(null);
 
-	const openLightbox = (url: string, name: string, btn: HTMLButtonElement) => {
+	const openLightbox = (url: string, name: string, btn: HTMLButtonElement): void => {
 		triggerButton = btn;
 		lightboxUrl = url;
 		lightboxName = name;
 	};
 
-	const closeLightbox = () => {
+	const closeLightbox = (): void => {
 		lightboxDialog?.close();
 	};
 
-	const onDialogClose = () => {
+	const onDialogClose = (): void => {
 		lightboxUrl = '';
 		lightboxName = '';
 		triggerButton?.focus();

--- a/src/routes/sitemap-2.xml/+server.ts
+++ b/src/routes/sitemap-2.xml/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
-import { fetchSitemapPosts, generateSitemapXml } from '$lib/server/sitemap';
+import { fetchSitemapPosts, generateSitemapXml, type StaticRoute } from '$lib/server/sitemap';
 
-const staticRoutes = [
+const staticRoutes: StaticRoute[] = [
 	{ path: '/', changefreq: 'daily', priority: '1.0' },
 	{ path: '/about', changefreq: 'monthly', priority: '0.8' },
 	{ path: '/archives', changefreq: 'monthly', priority: '0.6' },

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
-import { fetchSitemapPosts, generateSitemapXml } from '$lib/server/sitemap';
+import { fetchSitemapPosts, generateSitemapXml, type StaticRoute } from '$lib/server/sitemap';
 
-const staticRoutes = [
+const staticRoutes: StaticRoute[] = [
 	{ path: '/', changefreq: 'daily', priority: '1.0' },
 	{ path: '/about', changefreq: 'monthly', priority: '0.8' },
 	{ path: '/archives', changefreq: 'monthly', priority: '0.6' },


### PR DESCRIPTION
## Summary

**Monday TypeScript pass** — no `any` usage was found, and `interface` is used correctly (only for declaration merging in `app.d.ts`). This PR addresses the remaining typing gaps identified in the audit:

- **Extract `toDateStr` to a shared utility** (`src/lib/dateUtils.ts`): the same `function toDateStr(date: Date): string` was copy-pasted into `weatherStreak.ts`, `weekInHistory.ts`, and `weeklyDigest.ts`. All three now import from the shared location, eliminating the risk of future drift between the copies.

- **Add explicit return types to helper arrow functions** in `gallery/+page.svelte` (`openLightbox`, `closeLightbox`, `onDialogClose`) and the `pad` helper inside `fetchHistoricalWeather` in `historicalWeather.ts`.

- **Extract named `Props` type aliases** in `PostList.svelte` and `ShareButton.svelte`: these were the only two components that inlined the props type directly in the destructuring assignment rather than declaring a named `type Props = { ... }` first, inconsistent with every other component in the codebase.

- **Narrow `StaticRoute.changefreq` to `SitemapChangefreq`** (`'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never'`): the field was typed as `string`, making it possible to pass any value to the XML sitemap. The narrowing immediately caught both sitemap server files whose `staticRoutes` arrays were missing an explicit type annotation — now correctly annotated as `StaticRoute[]`.

## Test plan

- [x] `yarn lint` (Biome) — passes clean, 0 fixes applied
- [x] `yarn ts-check` (svelte-check) — 0 errors; 9 pre-existing Svelte 5 reactivity warnings in prerendered pages, unchanged from before this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013tr8McPAdvYgcz97ghLgQ7)_