### PR TITLE
test(dateUtils): add unit tests for toDateStr

### DIFF
--- a/src/lib/dateUtils.spec.ts
+++ b/src/lib/dateUtils.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { toDateStr } from './dateUtils';
+
+describe('toDateStr', () => {
+	it('returns a YYYY-MM-DD string for a mid-year date', () => {
+		expect(toDateStr(new Date('2026-07-14T12:00:00Z'))).toBe('2026-07-14');
+	});
+
+	it('zero-pads a single-digit month', () => {
+		expect(toDateStr(new Date('2026-01-15T12:00:00Z'))).toBe('2026-01-15');
+	});
+
+	it('zero-pads a single-digit day', () => {
+		expect(toDateStr(new Date('2026-07-05T12:00:00Z'))).toBe('2026-07-05');
+	});
+
+	it('uses UTC — a time of 23:59:59Z does not roll over to the next day', () => {
+		expect(toDateStr(new Date('2026-07-14T23:59:59Z'))).toBe('2026-07-14');
+	});
+
+	it('uses UTC — midnight exactly maps to the correct calendar date', () => {
+		expect(toDateStr(new Date('2026-07-14T00:00:00Z'))).toBe('2026-07-14');
+	});
+
+	it('handles a leap-year date (29 February) correctly', () => {
+		expect(toDateStr(new Date('2000-02-29T12:00:00Z'))).toBe('2000-02-29');
+	});
+
+	it('handles a year-end boundary (31 December) without rolling into the next year', () => {
+		expect(toDateStr(new Date('2025-12-31T23:00:00Z'))).toBe('2025-12-31');
+	});
+});


### PR DESCRIPTION
## Summary

- `src/lib/dateUtils.ts` exports `toDateStr` — a pure UTC date-formatter used by several API modules (`weeklyDigest`, `weekInHistory`, `weatherStreak`) — but had zero unit tests.
- Added `src/lib/dateUtils.spec.ts` with 7 tests covering all meaningful behaviours of the function.

## Tests added

| Test | What it verifies |
|------|-----------------|
| returns a YYYY-MM-DD string for a mid-year date | basic format |
| zero-pads a single-digit month | e.g. `2026-01-15` |
| zero-pads a single-digit day | e.g. `2026-07-05` |
| uses UTC — 23:59:59Z does not roll to the next day | UTC boundary correctness |
| uses UTC — midnight exactly maps to the correct date | UTC midnight correctness |
| handles a leap-year date (29 February) | Feb 29 in a leap year |
| handles a year-end boundary (31 December) | no year rollover at 23:00Z |

All 142 unit tests pass (`yarn test:unit --run`). `yarn lint` reports no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWsekHmhfJadp85AM4a5PF)_