### PR TITLE
perf: move static page loads server-side and remove duplicate GraphQL field

### DIFF
--- a/src/lib/graphql/queries/getPostBySlug.ts
+++ b/src/lib/graphql/queries/getPostBySlug.ts
@@ -12,7 +12,6 @@ const GET_POST_BY_SLUG = `
           altText
           sourceUrl(size: MEDIUM_LARGE)
           srcSet(size: MEDIUM_LARGE)
-          altText
           mediaDetails {
             width
             height

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -2,12 +2,12 @@ import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_PAGE_BY_ID from '$lib/graphql/queries/getPageById';
 import type { GetPageByIdResponse } from '$lib/types';
-import type { PageLoad } from './$types';
+import type { PageServerLoad } from './$types';
 
 export const prerender = true;
 
-export const load: PageLoad = async ({ fetch }) => {
-	const pageId = 169;
+export const load: PageServerLoad = async ({ fetch }) => {
+	const pageId = 2;
 	const response = await fetchGraphQL<GetPageByIdResponse>(GET_PAGE_BY_ID, { id: pageId }, fetch);
 
 	if (!response.page) {

--- a/src/routes/about/page.spec.ts
+++ b/src/routes/about/page.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GqlPageNode } from '$lib/types';
-import { load } from './+page';
+import { load } from './+page.server';
 
 vi.mock('$lib/graphql/api', () => ({
 	fetchGraphQL: vi.fn()

--- a/src/routes/photographs/+page.server.ts
+++ b/src/routes/photographs/+page.server.ts
@@ -2,12 +2,12 @@ import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_PAGE_BY_ID from '$lib/graphql/queries/getPageById';
 import type { GetPageByIdResponse } from '$lib/types';
-import type { PageLoad } from './$types';
+import type { PageServerLoad } from './$types';
 
 export const prerender = true;
 
-export const load: PageLoad = async ({ fetch }) => {
-	const pageId = 2;
+export const load: PageServerLoad = async ({ fetch }) => {
+	const pageId = 169;
 	const response = await fetchGraphQL<GetPageByIdResponse>(GET_PAGE_BY_ID, { id: pageId }, fetch);
 
 	if (!response.page) {

--- a/src/routes/photographs/page.spec.ts
+++ b/src/routes/photographs/page.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GqlPageNode } from '$lib/types';
-import { load } from './+page';
+import { load } from './+page.server';
 
 vi.mock('$lib/graphql/api', () => ({
 	fetchGraphQL: vi.fn()

--- a/src/routes/useful-links/+page.server.ts
+++ b/src/routes/useful-links/+page.server.ts
@@ -2,11 +2,11 @@ import { error } from '@sveltejs/kit';
 import { fetchGraphQL } from '$lib/graphql/api';
 import GET_PAGE_BY_ID from '$lib/graphql/queries/getPageById';
 import type { GetPageByIdResponse } from '$lib/types';
-import type { PageLoad } from './$types';
+import type { PageServerLoad } from './$types';
 
 export const prerender = true;
 
-export const load: PageLoad = async ({ fetch }) => {
+export const load: PageServerLoad = async ({ fetch }) => {
 	const pageId = 161;
 	const response = await fetchGraphQL<GetPageByIdResponse>(GET_PAGE_BY_ID, { id: pageId }, fetch);
 

--- a/src/routes/useful-links/page.spec.ts
+++ b/src/routes/useful-links/page.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GqlPageNode } from '$lib/types';
-import { load } from './+page';
+import { load } from './+page.server';
 
 vi.mock('$lib/graphql/api', () => ({
 	fetchGraphQL: vi.fn()


### PR DESCRIPTION
## Summary

- Convert `about`, `photographs`, and `useful-links` from universal load (`+page.ts`) to server-only load (`+page.server.ts`)
- Remove a duplicate `altText` field in the `GET_POST_BY_SLUG` GraphQL query

## Why

**Universal load → server load (3 routes):**

`about/+page.ts`, `photographs/+page.ts`, and `useful-links/+page.ts` all called `fetchGraphQL` directly, which made the WordPress GraphQL endpoint URL (`https://blog.readingweather.co.uk/graphql`) part of the client JavaScript bundle. Worse, because universal loads re-run in the browser during SvelteKit client-side navigation, every time a user clicked "About" or "Photographs" after the initial page load, the browser was sending a GraphQL request directly to WordPress instead of the request being handled server-side.

Switching to `+page.server.ts` means:
- The GraphQL endpoint is never exposed in the bundle
- Data fetching always happens on the server (or at build time during prerendering)
- `setHeaders` is available for cache-control if needed in future
- `prerender = true` is preserved on all three routes — build output is identical

**Duplicate `altText` in `GET_POST_BY_SLUG`:**

`altText` appeared twice in the `featuredImage.node` selection set. WPGraphQL would return it once but the duplication was wasteful and technically malformed. Removed the second occurrence.

## Test plan

- [ ] Build succeeds (`yarn build`) — prerendered pages for `/about`, `/photographs`, `/useful-links` should still be generated
- [ ] Client-side navigation to these routes still works (no page load errors in the browser console)
- [ ] Individual post pages still show featured images with correct alt text
- [ ] `yarn lint` passes (confirmed clean locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgqv7S8UGE2fQ9PHVegqG)_