### PR TITLE
chore(a11y/seo): accessibility and SEO improvements

### DIFF
--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -9,6 +9,11 @@
 
 	const { postId, parentCommentId = null }: Props = $props();
 
+	const fieldPrefix = $derived(
+		`${postId.replace(/[^a-zA-Z0-9]/g, '')}${parentCommentId ? `-${parentCommentId.replace(/[^a-zA-Z0-9]/g, '')}` : ''}`
+	);
+	const formHeadingId = $derived(`comment-form-heading-${fieldPrefix}`);
+
 	let name = $state('');
 	let email = $state('');
 	let commentContent = $state('');
@@ -51,20 +56,20 @@
 	}
 </script>
 
-<form class="add-comment" onsubmit={submitComment}>
-	<h2>{parentCommentId ? 'Reply to Comment' : 'Add Your Comment'}</h2>
+<form class="add-comment" aria-labelledby={formHeadingId} onsubmit={submitComment}>
+	<h2 id={formHeadingId}>{parentCommentId ? 'Reply to Comment' : 'Add Your Comment'}</h2>
 	{#if !successMessage}
 		<div>
-			<label for="name">Name:</label>
-			<input type="text" bind:value={name} id="name" name="name" autocomplete="name" required aria-required="true" />
+			<label for="name-{fieldPrefix}">Name:</label>
+			<input type="text" bind:value={name} id="name-{fieldPrefix}" name="name" autocomplete="name" required aria-required="true" />
 		</div>
 		<div>
-			<label for="email">Email:</label>
-			<input type="email" bind:value={email} id="email" name="email" autocomplete="email" required aria-required="true" />
+			<label for="email-{fieldPrefix}">Email:</label>
+			<input type="email" bind:value={email} id="email-{fieldPrefix}" name="email" autocomplete="email" required aria-required="true" />
 		</div>
 		<div>
-			<label for="comment">Comment:</label>
-			<textarea bind:value={commentContent} id="comment" name="comment" autocomplete="off" required aria-required="true"></textarea>
+			<label for="comment-{fieldPrefix}">Comment:</label>
+			<textarea bind:value={commentContent} id="comment-{fieldPrefix}" name="comment" autocomplete="off" required aria-required="true"></textarea>
 		</div>
 		<button type="submit" disabled={submitting}>
 			{submitting ? 'Submitting...' : 'Post Comment'}

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -37,7 +37,7 @@
 				</a>
 			{#if preview}
 					<div class="content">{@html sanitize(firstParagraph(post.content))}</div>
-					<a href="/{post.slug}" class="read-more">Read full forecast</a>
+					<a href="/{post.slug}" class="read-more" aria-label="Read full forecast for {post.title}">Read full forecast</a>
 				{:else}
 					<div class="content">{@html sanitize(injectKofiWidget(post.content))}</div>
 					<div class="comment-link">

--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -45,16 +45,16 @@
 		<button onclick={copyLink} aria-label="Copy link to this forecast">
 			{copied ? 'Copied!' : 'Copy link'}
 		</button>
-		<button onclick={shareOnBluesky} aria-label="Share this forecast on Bluesky">
+		<button onclick={shareOnBluesky} aria-label="Share this forecast on Bluesky (opens in new tab)">
 			Share on Bluesky
 		</button>
-		<button onclick={shareOnThreads} aria-label="Share this forecast on Threads">
+		<button onclick={shareOnThreads} aria-label="Share this forecast on Threads (opens in new tab)">
 			Share on Threads
 		</button>
-		<button onclick={shareOnFacebook} aria-label="Share this forecast on Facebook">
+		<button onclick={shareOnFacebook} aria-label="Share this forecast on Facebook (opens in new tab)">
 			Share on Facebook
 		</button>
-		<button onclick={shareOnWhatsApp} aria-label="Share this forecast on WhatsApp">
+		<button onclick={shareOnWhatsApp} aria-label="Share this forecast on WhatsApp (opens in new tab)">
 			Share on WhatsApp
 		</button>
 	</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,7 +45,7 @@
 	<link rel="preconnect" href="https://www.googletagmanager.com" />
 	<link rel="preload" href="/fonts/Caveat-VariableFont_wght.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
 	<link rel="preload" href="/fonts/FiraSans-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
-	<link rel="canonical" href={$page.url.href} />
+	<link rel="canonical" href={`https://www.readingweather.co.uk${$page.url.pathname}`} />
 	<meta property="og:site_name" content="Reading Weather" />
 	<meta property="og:locale" content="en_GB" />
 	<meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
 </main>
 
 <footer>
-	<section class="post">
+	<div class="post">
 		<h2 id="subscribe-heading">Be notified of new posts by e-mail</h2>
 <form id="subscribe-form" aria-labelledby="subscribe-heading" onsubmit={handleSubmit}>
 			<label for="subscribe-name">
@@ -74,6 +74,6 @@
 		</form>
 
 		<p class="response" role="status" aria-live="polite">{responseMessage}</p>
-	</section>
+	</div>
 	<p>&copy; {new Date().getFullYear()} Weather Forecast For Reading & Berkshire</p>
 </footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,11 @@
 	<meta property="og:title" content={data.meta.title} />
 	<meta property="og:description" content={data.meta.description} />
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
+	<meta name="twitter:title" content={data.meta.title} />
+	<meta name="twitter:description" content={data.meta.description} />
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -41,12 +41,22 @@
 	);
 	const postUrl = $derived(`https://www.readingweather.co.uk/${data.post.slug}`);
 
+	const ogImageUrl = $derived(
+		data.post.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'
+	);
+	const ogImageAlt = $derived(
+		data.post.featuredImage?.node?.sourceUrl
+			? (data.post.featuredImage.node.altText || `Weather forecast image for ${data.post.title}`)
+			: 'Weather forecast illustration for Reading and Berkshire'
+	);
+
 	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'BlogPosting',
 		headline: postTitle,
 		description: postDescription,
 		url: postUrl,
+		mainEntityOfPage: { '@type': 'WebPage', '@id': postUrl },
 		...(data.post.date ? { datePublished: data.post.date } : {}),
 		...(data.post.featuredImage?.node?.sourceUrl
 			? { image: data.post.featuredImage.node.sourceUrl }
@@ -96,14 +106,10 @@
 	<meta name="description" content={postDescription} />
 	<meta property="og:title" content={postTitle} />
 	<meta property="og:description" content={postDescription} />
-	<meta
-		property="og:image"
-		content={data.post.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'}
-	/>
-	<meta
-		name="twitter:image"
-		content={data.post.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'}
-	/>
+	<meta property="og:image" content={ogImageUrl} />
+	<meta property="og:image:alt" content={ogImageAlt} />
+	<meta name="twitter:image" content={ogImageUrl} />
+	<meta name="twitter:image:alt" content={ogImageAlt} />
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content={postUrl} />
 	<meta name="twitter:title" content={postTitle} />
@@ -125,7 +131,7 @@
 			src={data.post.featuredImage.node.sourceUrl}
 			srcset={data.post.featuredImage.node.srcSet}
 			sizes="(min-width: 768px) 700px, 100vw"
-			alt={data.post.featuredImage.node.altText ?? ''}
+			alt={data.post.featuredImage.node.altText || `Featured image for: ${data.post.title}`}
 			width={data.post.featuredImage.node.mediaDetails?.width ?? undefined}
 			height={data.post.featuredImage.node.mediaDetails?.height ?? undefined}
 			fetchpriority="high"

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -19,11 +19,13 @@
 	<meta property="og:title" content={data.page.title} />
 	<meta property="og:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
 	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
 	<meta name="twitter:title" content={data.page.title} />
 	<meta name="twitter:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
 	<meta name="twitter:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 

--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -45,16 +45,18 @@
 	<meta property="og:title" content="Weather Forecast Archives – Reading Weather" />
 	<meta property="og:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/archives" />
 	<meta name="twitter:title" content="Weather Forecast Archives – Reading Weather" />
 	<meta name="twitter:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
 <h1>Weather Forecast Archives</h1>
-<article class="post">
+<section class="post" aria-label="Archives">
 	<div class="archive-container">
 		<label for="archive-select">Select Month:</label>
 		<select id="archive-select" onchange={updateArchive}>
@@ -81,4 +83,4 @@
 			<p>Select a month to view posts.</p>
 		{/if}
 	</div>
-</article>
+</section>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -15,7 +15,7 @@
 		'@type': 'ImageGallery',
 		name: `Photo Gallery ${data.selectedYear} – Reading Weather`,
 		description: 'A photo gallery of weather conditions in Reading and Berkshire, organised by month and year.',
-		url: `https://www.readingweather.co.uk/gallery?year=${data.selectedYear}`
+		url: 'https://www.readingweather.co.uk/gallery'
 	});
 
 	const updateYear = (event: Event & { currentTarget: EventTarget & HTMLSelectElement }): void => {
@@ -59,11 +59,13 @@
 	<meta property="og:title" content="Photo Gallery – Reading Weather" />
 	<meta property="og:description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/gallery" />
 	<meta name="twitter:title" content="Photo Gallery – Reading Weather" />
 	<meta name="twitter:description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -21,11 +21,13 @@
 	<meta property="og:title" content={data.page.title} />
 	<meta property="og:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
 	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
 	<meta name="twitter:title" content={data.page.title} />
 	<meta name="twitter:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
 	<meta name="twitter:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 

--- a/src/routes/seasonal-forecasts/+page.svelte
+++ b/src/routes/seasonal-forecasts/+page.svelte
@@ -31,6 +31,7 @@
 		content={data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl ??
 			'https://www.readingweather.co.uk/images/weather.png'}
 	/>
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/seasonal-forecasts" />
 	<meta name="twitter:title" content="Seasonal Forecasts – Reading Weather" />
@@ -43,6 +44,7 @@
 		content={data.posts.posts.nodes[0]?.featuredImage?.node?.sourceUrl ??
 			'https://www.readingweather.co.uk/images/weather.png'}
 	/>
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 

--- a/src/routes/useful-links/+page.svelte
+++ b/src/routes/useful-links/+page.svelte
@@ -26,11 +26,13 @@
 		content={data.page.seo.opengraphDescription || data.page.seo.description}
 	/>
 	<meta property="og:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta property="og:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`https://www.readingweather.co.uk/${data.page.slug}`} />
 	<meta name="twitter:title" content={data.page.title} />
 	<meta name="twitter:description" content={data.page.seo.opengraphDescription || data.page.seo.description} />
 	<meta name="twitter:image" content={data.page.featuredImage?.node?.sourceUrl ?? 'https://www.readingweather.co.uk/images/weather.png'} />
+	<meta name="twitter:image:alt" content="Weather forecast illustration for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,6 +96,16 @@ main {
 	}
 }
 
+a:focus-visible {
+	outline: 3px solid #ffbf47;
+	outline-offset: 2px;
+}
+
+select:focus-visible {
+	outline: 3px solid #ffbf47;
+	outline-offset: 2px;
+}
+
 button {
 	background-color: var(--nav);
 	color: var(--white);
@@ -108,7 +118,7 @@ button {
 	&:focus-visible {
 		outline: 3px solid #ffbf47;
 		outline-offset: 2px;
-  }
+	}
 	&:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;


### PR DESCRIPTION
## Summary

Thursday automated run — Accessibility & SEO category (2026-07-16).

### SEO fixes
- **Canonical URL**: Fixed `+layout.svelte` to derive the canonical from `$page.url.pathname` only, preventing query-string variants (`?year=`, `?month=`) on the archives and gallery pages from generating duplicate canonical entries.
- **Missing twitter tags on home page**: Added `twitter:title` and `twitter:description` to `+page.svelte` — the only route that was missing them.
- **`og:image:alt` / `twitter:image:alt`**: Added descriptive alt text for OG/Twitter images on all 8 route pages. Social platform screen readers now have a meaningful description of the shared image.
- **Gallery JSON-LD URL**: The `ImageGallery` schema was emitting `url: .../gallery?year=2024` while `og:url` was `.../gallery`. Aligned both to the clean canonical path.
- **`BlogPosting` structured data**: Added `mainEntityOfPage` to the JSON-LD on post pages, as recommended by Google's structured data guidelines for articles.

### Accessibility fixes
- **Hero image alt fallback** (`[slug]/+page.svelte`): When the CMS supplies no `altText` for the featured image, the `alt` attribute was silently set to `""`, hiding a content-critical image from screen readers. Now falls back to `"Featured image for: {post title}"`.
- **Comment form ARIA** (`AddComment.svelte`):
  - Added `aria-labelledby` on the `<form>` element pointing to its `<h2>`, which now has a matching `id`. Matches the pattern already used in the subscribe form.
  - Made input `id` attributes unique per form instance using `postId` + `parentCommentId`, preventing duplicate `id` values when a reply form and the main comment form are both rendered on the same page.
- **"Read full forecast" links** (`PostList.svelte`): Added `aria-label="Read full forecast for {post.title}"` so screen reader link lists distinguish between multiple identical-text links.
- **Social share buttons** (`ShareButton.svelte`): Added `(opens in new tab)` to the `aria-label` of Bluesky, Threads, Facebook, and WhatsApp share buttons, as AT convention requires warning users when a button opens a new window.
- **Archives page semantic HTML**: Replaced `<article class="post">` with `<section class="post" aria-label="Archives">`. The archive filter UI is not independently distributable content, so `<article>` was the wrong element.
- **Footer subscribe wrapper**: Replaced `<section class="post">` with `<div class="post">` in the footer. A `<section>` without a visible name creates an unnamed landmark region, which is noise for screen reader users navigating by landmarks.
- **Focus styles for `<a>` and `<select>`** (`global.css`): Added `:focus-visible` outlines (`3px solid #ffbf47`) matching the existing button treatment, ensuring consistent and visible keyboard-navigation indicators across all interactive elements.

## Test plan
- [ ] `yarn lint` passes cleanly ✅
- [ ] Verify canonical tag in page source is pathname-only (no query string)
- [ ] Check social share preview (e.g. Twitter Card Validator) picks up twitter:title and image:alt
- [ ] Confirm comment form labels still associate correctly with inputs
- [ ] Tab through the site and confirm focus rings appear on links and selects

---
_Generated by [Claude Code](https://claude.ai/code/session_017qvU1ZonGfCU2VGEMCD6Lz)_