### PR TITLE
fix(typescript): resolve Svelte 5 reactivity warnings and tighten GqlPageSeo type

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,7 +35,7 @@ export type GqlPostNode = {
 
 export type GqlPageSeo = {
 	description: string;
-	opengraphDescription: string;
+	opengraphDescription: string | null;
 };
 
 export type GqlPageNode = {

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -4,13 +4,13 @@
 
 	const { data }: PageProps = $props();
 
-	const jsonLd = {
+	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`
-	};
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -6,13 +6,13 @@
 
 	import '../../styles/index.css';
 
-	const jsonLd = {
+	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`
-	};
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/useful-links/+page.svelte
+++ b/src/routes/useful-links/+page.svelte
@@ -8,13 +8,13 @@
 
 	const sanitizedContent = $derived(sanitize(data.page.content));
 
-	const jsonLd = {
+	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`
-	};
+	});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary

Today is Saturday 18 July 2026, so today's scheduled task picked a category at random — **TypeScript & typing** was selected. This PR applies the improvements found during analysis.

### Changes

**Fix Svelte 5 `state_referenced_locally` warnings (3 files)**

`about/+page.svelte`, `photographs/+page.svelte`, and `useful-links/+page.svelte` all built the JSON-LD structured-data object by reading from `data` (a `$props()` value) into a plain `const`. In Svelte 5's reactivity model this captures the *initial* value of `data` and does not update if the page data changes after mount (e.g., navigating between same-route pages). Wrapping each `jsonLd` object in `$derived()` — the same pattern already used in `+page.svelte` and `[slug]/+page.svelte` — resolves all 9 `svelte-check` warnings and ensures the `<script type="application/ld+json">` in `<svelte:head>` always reflects current page data.

**Tighten `GqlPageSeo.opengraphDescription` type (`src/lib/types.ts`)**

The Yoast WPGraphQL plugin exposes `opengraphDescription` as a nullable `String` field — it returns `null` when no OpenGraph description has been entered in the WordPress admin. The type was previously `string`, which misrepresented what the API can return. All consumer sites already guard with `|| fallback`, so changing to `string | null` is a no-op at runtime but correctly describes the contract.

**Update `biome.json` schema URL**

Minor: the `$schema` URL referenced Biome 2.5.3 while the installed version is 2.5.4. Updated to match, eliminating the informational mismatch message from `yarn lint`.

### Verification

- `yarn run svelte-check`: **0 errors, 0 warnings** (was 9 warnings before)
- `yarn test:unit --run`: **142 tests passed**
- `yarn lint`: **clean** (no errors or warnings)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5fgzYY8Y9Wx4xbkQmUD4K)_