### PR TITLE
chore(typescript): fix Svelte 5 reactivity warnings and extract named type

### DIFF
--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -126,6 +126,13 @@ export type WeatherStreakResult = {
 
 type Run = { startIndex: number; endIndex: number; length: number };
 
+type StreakCandidate = {
+	def: StreakDefinition;
+	length: number;
+	context: string;
+	definition?: string;
+};
+
 function findRuns(matches: boolean[]): Run[] {
 	const runs: Run[] = [];
 	let runStart = -1;
@@ -202,7 +209,7 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 		timeZone: 'UTC'
 	});
 
-	const candidates: { def: StreakDefinition; length: number; context: string; definition?: string }[] = [];
+	const candidates: StreakCandidate[] = [];
 
 	for (const def of STREAK_DEFINITIONS) {
 		const matches = days.map((d) => def.test(d));
@@ -225,7 +232,7 @@ export async function fetchWeatherStreak(now: Date = new Date()): Promise<Weathe
 
 	candidates.sort((a, b) => b.length - a.length);
 
-	const toStreak = (c: (typeof candidates)[number]): Streak => ({
+	const toStreak = (c: StreakCandidate): Streak => ({
 		type: c.def.type,
 		emoji: c.def.emoji,
 		length: c.length,

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -4,13 +4,13 @@
 
 	const { data }: PageProps = $props();
 
-	const jsonLd = {
+	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`
-	};
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/photographs/+page.svelte
+++ b/src/routes/photographs/+page.svelte
@@ -6,13 +6,13 @@
 
 	import '../../styles/index.css';
 
-	const jsonLd = {
+	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`
-	};
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/useful-links/+page.svelte
+++ b/src/routes/useful-links/+page.svelte
@@ -8,13 +8,13 @@
 
 	const sanitizedContent = $derived(sanitize(data.page.content));
 
-	const jsonLd = {
+	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`
-	};
+	});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary

- **Fix 9 svelte-check warnings** in `about`, `photographs`, and `useful-links` page components: `jsonLd` objects that referenced `data.page.*` properties were constructed as plain `const` assignments, causing Svelte 5 to warn that only the initial value of `data` was captured (`state_referenced_locally`). Wrapping each in `$derived()` makes the dependency tracking explicit and matches the pattern already used in `[slug]/+page.svelte`.
- **Extract `StreakCandidate` named type** in `src/lib/api/weatherStreak.ts`: the `candidates` array had an anonymous inline object type (`{ def: StreakDefinition; length: number; context: string; definition?: string }`) repeated across the array declaration and `toStreak` parameter. Replacing it with a named `StreakCandidate` alias is consistent with the rest of the file's style.

## What was checked

- `yarn ts-check` (`svelte-check --tsconfig ./tsconfig.json`): went from **9 warnings across 3 files** → **0 errors, 0 warnings**
- `yarn lint` (`biome check .`): passes cleanly (exit 0; the only output is an informational note about the biome schema version already present on main)
- No `any` usages exist anywhere in the codebase; the single `interface` declaration (`interface Window` in `app.d.ts`) is a correct declaration-merge augmentation and was left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQwVkf1aaPDpC6G6R7mhQ2)_