### PR TITLE
feat(tests): add 7 unit tests covering cache hit paths and untested load branches

### DIFF
--- a/src/lib/graphql/api.spec.ts
+++ b/src/lib/graphql/api.spec.ts
@@ -138,3 +138,22 @@ describe('fetchGraphQL — non-JSON response', () => {
 		);
 	});
 });
+
+describe('fetchGraphQL — custom fetchFn', () => {
+	it('uses the provided fetchFn instead of the global fetch, passing the correct URL and variables', async () => {
+		const jsonHeaders = { get: (key: string) => (key === 'content-type' ? 'application/json' : null) };
+		const customFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			headers: jsonHeaders,
+			json: async () => ({ data: { result: true } })
+		});
+
+		await fetchGraphQL('{ result }', { foo: 'bar' }, customFetch as unknown as typeof fetch);
+
+		expect(customFetch).toHaveBeenCalledTimes(1);
+		const [url, opts] = customFetch.mock.calls[0] as [string, { body: string }];
+		expect(url).toBe('https://blog.readingweather.co.uk/graphql');
+		const body = JSON.parse(opts.body) as { variables: Record<string, unknown> };
+		expect(body.variables).toEqual({ foo: 'bar' });
+	});
+});

--- a/src/routes/api/historical-weather/server.spec.ts
+++ b/src/routes/api/historical-weather/server.spec.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from './+server';
+
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn((key: string) => cacheStore.get(key) ?? null),
+	setCache: vi.fn((key: string, data: unknown) => {
+		cacheStore.set(key, data);
+	})
+}));
 
 vi.mock('$lib/api/historicalWeather', () => ({
 	fetchHistoricalWeather: vi.fn().mockResolvedValue([
@@ -14,11 +23,18 @@ vi.mock('$lib/api/historicalWeather', () => ({
 	])
 }));
 
+import { fetchHistoricalWeather } from '$lib/api/historicalWeather';
+
 function makeEvent(params: Record<string, string> = {}) {
 	const url = new URL('http://localhost/api/historical-weather');
 	for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
 	return { url } as Parameters<typeof GET>[0];
 }
+
+beforeEach(() => {
+	cacheStore.clear();
+	vi.clearAllMocks();
+});
 
 describe('GET /api/historical-weather', () => {
 	it('returns 400 with an error message when month or day is missing', async () => {
@@ -29,10 +45,41 @@ describe('GET /api/historical-weather', () => {
 	});
 
 	it('returns 200 with weather data when both month and day are provided', async () => {
+		vi.mocked(fetchHistoricalWeather).mockResolvedValueOnce([
+			{
+				year: 2025,
+				tempMax: 20,
+				tempMin: 10,
+				precipitation: 5,
+				windSpeedMax: 15,
+				conditions: { morning: 'clear sky', afternoon: 'partly cloudy', evening: 'mainly clear' }
+			}
+		]);
 		const response = await GET(makeEvent({ month: '6', day: '15' }));
 		expect(response.status).toBe(200);
 		const body = await response.json();
 		expect(Array.isArray(body)).toBe(true);
 		expect(body[0].year).toBe(2025);
+	});
+
+	it('returns cached data without calling fetchHistoricalWeather on a cache hit', async () => {
+		const cachedData = [
+			{
+				year: 2024,
+				tempMax: 18,
+				tempMin: 9,
+				precipitation: 3,
+				windSpeedMax: 12,
+				conditions: { morning: 'rain', afternoon: 'overcast', evening: 'clear sky' }
+			}
+		];
+		cacheStore.set('historical-weather-6-15', cachedData);
+
+		const response = await GET(makeEvent({ month: '6', day: '15' }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body[0].year).toBe(2024);
+		expect(fetchHistoricalWeather).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/api/weather-streak/server.spec.ts
+++ b/src/routes/api/weather-streak/server.spec.ts
@@ -87,4 +87,17 @@ describe('GET /api/weather-streak', () => {
 		expect(await response.json()).toBeNull();
 		expect(fetchWeatherStreak).not.toHaveBeenCalled();
 	});
+
+	it('returns cached streak data without calling the upstream when a successful result is cached', async () => {
+		vi.mocked(fetchWeatherStreak).mockResolvedValue(mockStreak);
+		await GET({} as Parameters<typeof GET>[0]);
+
+		vi.mocked(fetchWeatherStreak).mockClear();
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.active.headline).toBe('14 consecutive dry days in Reading');
+		expect(fetchWeatherStreak).not.toHaveBeenCalled();
+	});
 });

--- a/src/routes/api/week-in-history/server.spec.ts
+++ b/src/routes/api/week-in-history/server.spec.ts
@@ -61,4 +61,17 @@ describe('GET /api/week-in-history', () => {
 		expect(response.status).toBe(502);
 		expect(fetchWeekInHistory).not.toHaveBeenCalled();
 	});
+
+	it('returns cached history without calling fetchWeekInHistory when data is already cached', async () => {
+		vi.mocked(fetchWeekInHistory).mockResolvedValue(mockHistory);
+		await GET({} as Parameters<typeof GET>[0]);
+
+		vi.mocked(fetchWeekInHistory).mockClear();
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.hottestDay).toEqual({ year: 2003, value: 31.5 });
+		expect(fetchWeekInHistory).not.toHaveBeenCalled();
+	});
 });

--- a/src/routes/api/weekly-digest/server.spec.ts
+++ b/src/routes/api/weekly-digest/server.spec.ts
@@ -66,4 +66,17 @@ describe('GET /api/weekly-digest', () => {
 		expect(response.status).toBe(502);
 		expect(fetchWeeklyDigest).not.toHaveBeenCalled();
 	});
+
+	it('returns cached digest without calling fetchWeeklyDigest when data is already cached', async () => {
+		vi.mocked(fetchWeeklyDigest).mockResolvedValue(mockDigest);
+		await GET({} as Parameters<typeof GET>[0]);
+
+		vi.mocked(fetchWeeklyDigest).mockClear();
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.dominantConditions).toBe('partly cloudy');
+		expect(fetchWeeklyDigest).not.toHaveBeenCalled();
+	});
 });

--- a/src/routes/page.spec.ts
+++ b/src/routes/page.spec.ts
@@ -104,4 +104,28 @@ describe('home page load', () => {
 
 		expect(result.onThisDay).toBeNull();
 	});
+
+	it('passes through historicalWeather data when the internal API call succeeds', async () => {
+		vi.mocked(fetchGraphQL)
+			.mockResolvedValueOnce(mockPosts)
+			.mockResolvedValueOnce(mockSeasonalResponse)
+			.mockResolvedValueOnce(mockOnThisDay);
+		const weatherData = [{ year: 2024, tempMax: 22, tempMin: 11, precipitation: 0, windSpeedMax: 10, conditions: { morning: 'clear sky', afternoon: 'mainly clear', evening: 'clear sky' } }];
+		mockFetch.mockResolvedValueOnce({ ok: true, json: async () => weatherData });
+
+		const result = await load({ setHeaders: vi.fn(), fetch: mockFetch } as unknown as Parameters<typeof load>[0]) as LoadResult;
+
+		expect(result.historicalWeather).toEqual(weatherData);
+	});
+
+	it('falls back to empty posts when the allPosts fetchGraphQL call fails', async () => {
+		vi.mocked(fetchGraphQL)
+			.mockRejectedValueOnce(new Error('GraphQL down'))
+			.mockResolvedValueOnce(mockSeasonalResponse)
+			.mockResolvedValueOnce(mockOnThisDay);
+
+		const result = await load({ setHeaders: vi.fn(), fetch: mockFetch } as unknown as Parameters<typeof load>[0]) as LoadResult;
+
+		expect(result.posts).toEqual({ posts: { nodes: [] } });
+	});
 });


### PR DESCRIPTION
## Summary

- **Cache hit coverage** — four API routes (`historical-weather`, `weather-streak`, `weekly-digest`, `week-in-history`) all have caching logic, but the success-data cache hit path was either entirely untested (`historical-weather`) or only partially tested (null/error paths existed, but not the non-null data path). Added a cache hit test for each, plus a proper cache mock to `historical-weather/server.spec.ts` so tests are isolated.
- **Home page load** — the `historicalWeather` success branch (where the internal API responds `ok: true`) was never exercised; all existing tests stub `mockFetch` to return `{ ok: false }`. Added a test for the success path. Also added a test that when the `allPosts` GraphQL call fails, the load falls back to `{ posts: { nodes: [] } }` rather than throwing.
- **`fetchGraphQL` custom `fetchFn`** — the third parameter lets callers supply their own fetch function (used by SvelteKit's `load` to enable SSR caching), but this was never verified. Added a test that confirms the provided function is called and that `variables` are forwarded correctly.

## Test plan

- [ ] `yarn test:unit --run` passes with all 156 tests green (149 existing + 7 new)
- [ ] `yarn lint` reports no errors or warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZNbyxUJtoVrHvkfpQYzF6)_