### PR TITLE
perf: add srcset to gallery images and decoding=async to lazy images

### DIFF
--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -31,6 +31,7 @@
 							height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 							loading={i === 0 ? 'eager' : 'lazy'}
 							fetchpriority={i === 0 ? 'high' : undefined}
+							decoding={i === 0 ? undefined : 'async'}
 						/>
 					{/if}
 					<h2>{post.title}</h2>

--- a/src/lib/graphql/queries/getPostsForGallery.ts
+++ b/src/lib/graphql/queries/getPostsForGallery.ts
@@ -8,6 +8,7 @@ const GET_POSTS_FOR_GALLERY = `
         featuredImage {
           node {
             sourceUrl
+            srcSet(size: MEDIUM_LARGE)
             mediaDetails {
               width
               height

--- a/src/routes/gallery/+page.server.ts
+++ b/src/routes/gallery/+page.server.ts
@@ -15,14 +15,14 @@ type GalleryPost = {
 	title: string;
 	slug: string;
 	date: string;
-	featuredImage?: { node?: { sourceUrl: string; mediaDetails?: MediaDetails } };
+	featuredImage?: { node?: { sourceUrl: string; srcSet?: string; mediaDetails?: MediaDetails } };
 };
 
 type GalleryPostFiltered = {
 	title: string;
 	slug: string;
 	date: string;
-	featuredImage: { node: { sourceUrl: string; mediaDetails?: MediaDetails } };
+	featuredImage: { node: { sourceUrl: string; srcSet?: string; mediaDetails?: MediaDetails } };
 };
 
 export type GalleryPostWithImage = GalleryPostFiltered & { name: string };

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -104,10 +104,13 @@
 								<button onclick={(e) => openLightbox(post.featuredImage.node.sourceUrl, post.name, e.currentTarget as HTMLButtonElement, post.featuredImage.node.mediaDetails?.width, post.featuredImage.node.mediaDetails?.height)} aria-label="View full size: {post.name}">
 									<img
 										src={post.featuredImage.node.sourceUrl}
+										srcset={post.featuredImage.node.srcSet}
+										sizes="(min-width: 480px) 200px, 100vw"
 										alt={post.name}
 										width={post.featuredImage.node.mediaDetails?.width ?? undefined}
 										height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 										loading="lazy"
+										decoding="async"
 									/>
 									<span class="photo-name" aria-hidden="true">{post.name}</span>
 								</button>


### PR DESCRIPTION
## Summary

- **Gallery images now use `srcset`**: The `GetPostsForGallery` GraphQL query was not requesting WordPress's `srcSet` field, so every gallery thumbnail always loaded the full-size image. Added `srcSet(size: MEDIUM_LARGE)` to the query, updated the corresponding types (`GalleryPost`, `GalleryPostFiltered`), and wired `srcset` + `sizes` attributes onto the thumbnail `<img>` elements. The browser can now pick an appropriately-sized image for each viewport (e.g. ~200px on desktop grids instead of the full-resolution original).
- **`decoding="async"` on lazy-loaded images**: Added `decoding="async"` to gallery thumbnail images and to non-LCP PostList images (`i > 0`). This moves image decode off the main thread, reducing main-thread jank when many images are being decoded simultaneously. The LCP candidates (PostList first image with `fetchpriority="high"`, slug-page featured image) are left without a `decoding` override so the browser's default `auto` behaviour applies — avoiding any risk of delaying the LCP metric.

## Changes

| File | Change |
|---|---|
| `src/lib/graphql/queries/getPostsForGallery.ts` | Add `srcSet(size: MEDIUM_LARGE)` to gallery query |
| `src/routes/gallery/+page.server.ts` | Add `srcSet?: string` to `GalleryPost` and `GalleryPostFiltered` types |
| `src/routes/gallery/+page.svelte` | Add `srcset`, `sizes`, `decoding="async"` to thumbnail `<img>` |
| `src/lib/components/PostList.svelte` | Add `decoding={i === 0 ? undefined : 'async'}` to post images |

## Category

Wednesday — Performance & SvelteKit optimisation

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9S3FpdHD65b8RMexm8Vr5)_