### PR TITLE
feat: Monthly Weather Report Card (#413)

### DIFF
--- a/src/lib/api/monthlySummary.spec.ts
+++ b/src/lib/api/monthlySummary.spec.ts
@@ -1,4 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn((key: string) => cacheStore.get(key) ?? null),
+	setCache: vi.fn((key: string, data: unknown) => {
+		cacheStore.set(key, data);
+	})
+}));
+
 import { fetchMonthlySummary } from './monthlySummary';
 
 // "Now" is set well into July so June 2026 is a fully completed month.
@@ -73,6 +83,7 @@ function makeArchiveResponse() {
 
 describe('fetchMonthlySummary', () => {
 	beforeEach(() => {
+		cacheStore.clear();
 		vi.useFakeTimers();
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse()));
 	});
@@ -88,12 +99,23 @@ describe('fetchMonthlySummary', () => {
 		);
 	});
 
-	it('requests a single continuous range from 1940 through the requested month', async () => {
+	it('requests a single continuous range from 1940 through the last complete year for this month', async () => {
 		await fetchMonthlySummary(2026, 6, NOW);
 		const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
 		const params = new URL(calledUrl).searchParams;
 		expect(params.get('start_date')).toBe('1940-06-01');
 		expect(params.get('end_date')).toBe('2026-06-30');
+	});
+
+	it('reuses the cached historical baseline across different years of the same month, without refetching', async () => {
+		await fetchMonthlySummary(2026, 6, NOW);
+		expect(fetch).toHaveBeenCalledTimes(1);
+
+		const summary2020 = await fetchMonthlySummary(2020, 6, NOW);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(summary2020.temperature.mean).toBe(20.0);
+		expect(summary2020.temperatureRank).toBe(1);
 	});
 
 	it('reports the requested year’s high, low and mean temperature', async () => {

--- a/src/lib/api/monthlySummary.spec.ts
+++ b/src/lib/api/monthlySummary.spec.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchMonthlySummary } from './monthlySummary';
+
+// "Now" is set well into July so June 2026 is a fully completed month.
+const NOW = new Date('2026-07-15T12:00:00Z');
+
+function juneDates(year: number): string[] {
+	const days = new Date(Date.UTC(year, 6, 0)).getUTCDate();
+	return Array.from(
+		{ length: days },
+		(_, i) => `${year}-06-${String(i + 1).padStart(2, '0')}`
+	);
+}
+
+// Only a handful of years have data — the rest of the 1940-2026 range is simply
+// absent from the response, which fetchMonthlySummary should skip over silently.
+function makeArchiveResponse() {
+	const years = [1962, 1971, 2020, 2026];
+	const time = years.flatMap(juneDates);
+
+	function fill(year: number, value: number, hotDayValue?: number) {
+		const days = juneDates(year).length;
+		const arr = new Array(days).fill(value);
+		if (hotDayValue !== undefined) arr[19] = hotDayValue; // 20th of June
+		return arr;
+	}
+
+	const temperature_2m_max = [
+		...fill(1962, 18.0),
+		...fill(1971, 19.0),
+		...fill(2020, 20.0),
+		...fill(2026, 22.0, 32.1) // 2026 has the all-time hottest day
+	];
+	const temperature_2m_min = [
+		...fill(1962, 8.0, 1.2), // 1962 has the all-time coldest day
+		...fill(1971, 9.0),
+		...fill(2020, 10.0),
+		...fill(2026, 9.2)
+	];
+	const temperature_2m_mean = [
+		...fill(1962, 13.0),
+		...fill(1971, 14.0),
+		...fill(2020, 20.0), // 2020 is the warmest June on record by mean temp
+		...fill(2026, 17.1)
+	];
+	const precipitation_sum = [
+		...fill(1962, 1.0),
+		...fill(1971, 1.0, 40.5), // 1971 has the all-time wettest day
+		...fill(2020, 1.0),
+		...fill(2026, 1.0, 18.2)
+	];
+	const sunshine_duration = [
+		...fill(1962, 5 * 3600),
+		...fill(1971, 5 * 3600),
+		...fill(2020, 5 * 3600),
+		...fill(2026, 5 * 3600, 14.8 * 3600)
+	];
+
+	return {
+		ok: true,
+		json: async () => ({
+			daily: {
+				time,
+				temperature_2m_max,
+				temperature_2m_min,
+				temperature_2m_mean,
+				precipitation_sum,
+				sunshine_duration
+			}
+		})
+	};
+}
+
+describe('fetchMonthlySummary', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse()));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('throws when the requested month has not yet fully completed', async () => {
+		await expect(fetchMonthlySummary(2026, 7, NOW)).rejects.toThrow(
+			'Monthly summary is only available for fully completed months'
+		);
+	});
+
+	it('requests a single continuous range from 1940 through the requested month', async () => {
+		await fetchMonthlySummary(2026, 6, NOW);
+		const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+		const params = new URL(calledUrl).searchParams;
+		expect(params.get('start_date')).toBe('1940-06-01');
+		expect(params.get('end_date')).toBe('2026-06-30');
+	});
+
+	it('reports the requested year’s high, low and mean temperature', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.temperature.high).toBe(32.1);
+		expect(summary.temperature.low).toBe(9.2);
+		expect(summary.temperature.mean).toBe(17.1);
+	});
+
+	it('ranks the requested year by mean temperature against all other years', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		// 2020 (mean 20.0) > 2026 (mean 17.1) > 1971 (14.0) > 1962 (13.0)
+		expect(summary.temperatureRank).toBe(2);
+		expect(summary.headline).toBe('June 2026 was the 2nd warmest June in Reading since 1940');
+	});
+
+	it('finds the all-time hottest, coldest and wettest days across the dataset', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.records.hottestDay).toEqual({ date: '2026-06-20', year: 2026, value: 32.1 });
+		expect(summary.records.coldestDay).toEqual({ date: '1962-06-20', year: 1962, value: 1.2 });
+		expect(summary.records.wettestDay).toEqual({ date: '1971-06-20', year: 1971, value: 40.5 });
+	});
+
+	it('finds the wettest and sunniest day within the requested month specifically', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.rainfall.wettestDay).toEqual({ date: '2026-06-20', value: 18.2 });
+		expect(summary.sunshine.sunniestDay).toEqual({ date: '2026-06-20', hours: 14.8 });
+	});
+
+	it('counts years of data present in the response', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.yearsOfData).toBe(4);
+	});
+
+	it('throws when the API request fails', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+		await expect(fetchMonthlySummary(2026, 6, NOW)).rejects.toThrow('Open-Meteo error: 500');
+	});
+
+	it('throws with a descriptive message when the archive response contains no data for the month', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					daily: {
+						time: [],
+						temperature_2m_max: [],
+						temperature_2m_min: [],
+						temperature_2m_mean: [],
+						precipitation_sum: [],
+						sunshine_duration: []
+					}
+				})
+			})
+		);
+		await expect(fetchMonthlySummary(2026, 6, NOW)).rejects.toThrow(
+			'No historical data available for this month'
+		);
+	});
+});

--- a/src/lib/api/monthlySummary.spec.ts
+++ b/src/lib/api/monthlySummary.spec.ts
@@ -73,10 +73,12 @@ function makeArchiveResponse() {
 
 describe('fetchMonthlySummary', () => {
 	beforeEach(() => {
+		vi.useFakeTimers();
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeArchiveResponse()));
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllGlobals();
 	});
 
@@ -129,6 +131,53 @@ describe('fetchMonthlySummary', () => {
 	it('throws when the API request fails', async () => {
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		await expect(fetchMonthlySummary(2026, 6, NOW)).rejects.toThrow('Open-Meteo error: 500');
+	});
+
+	it('retries after a 429 and succeeds once the upstream stops rate-limiting', async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: false, status: 429, headers: new Headers() })
+			.mockResolvedValueOnce(makeArchiveResponse());
+		vi.stubGlobal('fetch', mockFetch);
+
+		const summaryPromise = fetchMonthlySummary(2026, 6, NOW);
+		await vi.runAllTimersAsync();
+		const summary = await summaryPromise;
+
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+		expect(summary.temperature.high).toBe(32.1);
+	});
+
+	it('honours a Retry-After header when backing off a 429', async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 429,
+				headers: new Headers({ 'retry-after': '2' })
+			})
+			.mockResolvedValueOnce(makeArchiveResponse());
+		vi.stubGlobal('fetch', mockFetch);
+
+		const summaryPromise = fetchMonthlySummary(2026, 6, NOW);
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1000);
+		await summaryPromise;
+
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it('gives up after repeated 429s and surfaces the error', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({ ok: false, status: 429, headers: new Headers() })
+		);
+
+		const summaryPromise = fetchMonthlySummary(2026, 6, NOW);
+		const assertion = expect(summaryPromise).rejects.toThrow('Open-Meteo error: 429');
+		await vi.runAllTimersAsync();
+		await assertion;
 	});
 
 	it('throws with a descriptive message when the archive response contains no data for the month', async () => {

--- a/src/lib/api/monthlySummary.ts
+++ b/src/lib/api/monthlySummary.ts
@@ -1,4 +1,5 @@
 import { toDateStr } from '$lib/dateUtils';
+import { getCache, setCache } from '$lib/server/cache';
 
 const READING_LAT = 51.4543;
 const READING_LON = -0.9781;
@@ -8,7 +9,14 @@ const EARLIEST_YEAR = 1940;
 
 // A single continuous-range request covering every year back to 1940 takes a few
 // seconds to generate upstream, so give it more headroom than the 7-day digest fetch.
-const REQUEST_TIMEOUT_MS = 15000;
+const REQUEST_TIMEOUT_MS = 20000;
+
+// The multi-decade historical comparison for a given calendar month is the same no
+// matter which year's report card is being viewed, so it's cached independently of
+// the requested year and reused across every /monthly-summary/*/06 page there is.
+// It's keyed on the last complete year included (see lastCompleteYearForMonth), which
+// only advances once a year, so this is effectively immutable for a long stretch.
+const BASELINE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 type OpenMeteoArchiveResponse = {
 	daily: {
@@ -65,6 +73,15 @@ type YearStats = {
 	mean: number;
 	rain: number;
 	sunshineHours: number;
+	wettestDay: { date: string; value: number };
+	sunniestDay: { date: string; hours: number };
+};
+
+type MonthlyBaseline = {
+	yearStats: YearStats[];
+	hottestDay: DayRecord;
+	coldestDay: DayRecord;
+	wettestDay: DayRecord;
 };
 
 function monthBounds(year: number, month: number): { start: Date; end: Date } {
@@ -97,10 +114,20 @@ function indicesInRange(indexByDate: Map<string, number>, start: Date, end: Date
 	return indices;
 }
 
-// This full-range request is heavy enough (86 years of daily data across 5 variables)
-// that browsing between several months in quick succession can trip Open-Meteo's rate
-// limit. Retry a 429 a couple of times, honouring Retry-After when the upstream sends one,
-// rather than surfacing a spurious failure for what is otherwise a valid request.
+// The last year for which `month` has fully played out in real life — this is the
+// upper bound of every historical baseline, independent of whichever year's report
+// card a visitor happens to be looking at.
+function lastCompleteYearForMonth(month: number, now: Date): number {
+	const currentYear = now.getUTCFullYear();
+	const yesterday = new Date(now);
+	yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+	return monthBounds(currentYear, month).end <= yesterday ? currentYear : currentYear - 1;
+}
+
+// A request spanning every year back to 1940 is heavy enough that browsing between
+// several months in quick succession can trip Open-Meteo's rate limit. Retry a 429 a
+// couple of times, honouring Retry-After when the upstream sends one, rather than
+// surfacing a spurious failure for what is otherwise a valid request.
 const MAX_ATTEMPTS = 3;
 
 async function fetchArchive(url: string): Promise<Response> {
@@ -116,26 +143,19 @@ async function fetchArchive(url: string): Promise<Response> {
 	return response as Response;
 }
 
-export async function fetchMonthlySummary(
-	year: number,
-	month: number,
-	now: Date = new Date()
-): Promise<MonthlySummary> {
-	const { start, end } = monthBounds(year, month);
-
-	const yesterday = new Date(now);
-	yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-	if (end > yesterday) {
-		throw new Error('Monthly summary is only available for fully completed months');
-	}
+async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<MonthlyBaseline> {
+	const cacheKey = `monthly-baseline-${month}-${upToYear}`;
+	const cached = getCache<MonthlyBaseline>(cacheKey);
+	if (cached) return cached;
 
 	const rangeStart = new Date(Date.UTC(EARLIEST_YEAR, month - 1, 1));
+	const rangeEnd = monthBounds(upToYear, month).end;
 
 	const params = new URLSearchParams({
 		latitude: String(READING_LAT),
 		longitude: String(READING_LON),
 		start_date: toDateStr(rangeStart),
-		end_date: toDateStr(end),
+		end_date: toDateStr(rangeEnd),
 		daily:
 			'temperature_2m_max,temperature_2m_min,temperature_2m_mean,precipitation_sum,sunshine_duration',
 		timezone: 'Europe/London'
@@ -160,7 +180,7 @@ export async function fetchMonthlySummary(
 	let coldestDay: DayRecord | null = null;
 	let wettestDay: DayRecord | null = null;
 
-	for (let y = EARLIEST_YEAR; y <= year; y++) {
+	for (let y = EARLIEST_YEAR; y <= upToYear; y++) {
 		const bounds = monthBounds(y, month);
 		const indices = indicesInRange(indexByDate, bounds.start, bounds.end);
 		if (indices.length === 0) continue;
@@ -170,9 +190,13 @@ export async function fetchMonthlySummary(
 		const mean = indices.reduce((sum, i) => sum + temperature_2m_mean[i], 0) / indices.length;
 		const rain = indices.reduce((sum, i) => sum + precipitation_sum[i], 0);
 		const sunshineHours = indices.reduce((sum, i) => sum + sunshine_duration[i], 0) / 3600;
-		yearStats.push({ year: y, high, low, mean, rain, sunshineHours });
 
+		let wettestIdx = indices[0];
+		let sunniestIdx = indices[0];
 		for (const i of indices) {
+			if (precipitation_sum[i] > precipitation_sum[wettestIdx]) wettestIdx = i;
+			if (sunshine_duration[i] > sunshine_duration[sunniestIdx]) sunniestIdx = i;
+
 			const date = time[i];
 			if (!hottestDay || temperature_2m_max[i] > hottestDay.value) {
 				hottestDay = { date, year: y, value: Math.round(temperature_2m_max[i] * 10) / 10 };
@@ -184,37 +208,75 @@ export async function fetchMonthlySummary(
 				wettestDay = { date, year: y, value: Math.round(precipitation_sum[i] * 10) / 10 };
 			}
 		}
+
+		yearStats.push({
+			year: y,
+			high,
+			low,
+			mean,
+			rain,
+			sunshineHours,
+			wettestDay: {
+				date: time[wettestIdx],
+				value: Math.round(precipitation_sum[wettestIdx] * 10) / 10
+			},
+			sunniestDay: {
+				date: time[sunniestIdx],
+				hours: Math.round((sunshine_duration[sunniestIdx] / 3600) * 10) / 10
+			}
+		});
 	}
 
-	const targetYearStats = yearStats.find((s) => s.year === year);
-	if (!targetYearStats || !hottestDay || !coldestDay || !wettestDay) {
+	if (!hottestDay || !coldestDay || !wettestDay) {
 		throw new Error('No historical data available for this month');
 	}
 
-	const historicalAverageMean = yearStats.reduce((sum, s) => sum + s.mean, 0) / yearStats.length;
-	const historicalAverageTotal = yearStats.reduce((sum, s) => sum + s.rain, 0) / yearStats.length;
-	const historicalAverageHours =
-		yearStats.reduce((sum, s) => sum + s.sunshineHours, 0) / yearStats.length;
+	const baseline: MonthlyBaseline = { yearStats, hottestDay, coldestDay, wettestDay };
+	setCache(cacheKey, baseline, BASELINE_TTL_MS);
+	return baseline;
+}
 
-	const rankedByMean = [...yearStats].sort((a, b) => b.mean - a.mean);
+export async function fetchMonthlySummary(
+	year: number,
+	month: number,
+	now: Date = new Date()
+): Promise<MonthlySummary> {
+	const { start, end } = monthBounds(year, month);
+
+	const yesterday = new Date(now);
+	yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+	if (end > yesterday) {
+		throw new Error('Monthly summary is only available for fully completed months');
+	}
+
+	// The requested year's own month is, by construction, already within
+	// 1940..lastCompleteYearForMonth, so the baseline always has an entry for it —
+	// no separate network call is needed to fetch that specific month's own data.
+	const baseline = await fetchMonthlyBaseline(month, lastCompleteYearForMonth(month, now));
+
+	const targetYearStats = baseline.yearStats.find((s) => s.year === year);
+	if (!targetYearStats) {
+		throw new Error('No historical data available for this month');
+	}
+
+	const historicalAverageMean =
+		baseline.yearStats.reduce((sum, s) => sum + s.mean, 0) / baseline.yearStats.length;
+	const historicalAverageTotal =
+		baseline.yearStats.reduce((sum, s) => sum + s.rain, 0) / baseline.yearStats.length;
+	const historicalAverageHours =
+		baseline.yearStats.reduce((sum, s) => sum + s.sunshineHours, 0) / baseline.yearStats.length;
+
+	const rankedByMean = [...baseline.yearStats].sort((a, b) => b.mean - a.mean);
 	const temperatureRank = rankedByMean.findIndex((s) => s.year === year) + 1;
 
 	const monthName = start.toLocaleDateString('en-GB', { month: 'long', timeZone: 'UTC' });
-
-	const targetIndices = indicesInRange(indexByDate, start, end);
-	let wettestDayIdx = targetIndices[0];
-	let sunniestDayIdx = targetIndices[0];
-	for (const i of targetIndices) {
-		if (precipitation_sum[i] > precipitation_sum[wettestDayIdx]) wettestDayIdx = i;
-		if (sunshine_duration[i] > sunshine_duration[sunniestDayIdx]) sunniestDayIdx = i;
-	}
 
 	return {
 		year,
 		month,
 		monthName,
 		label: `${monthName} ${year}`,
-		yearsOfData: yearStats.length,
+		yearsOfData: baseline.yearStats.length,
 		temperature: {
 			high: Math.round(targetYearStats.high * 10) / 10,
 			low: Math.round(targetYearStats.low * 10) / 10,
@@ -223,26 +285,20 @@ export async function fetchMonthlySummary(
 		},
 		rainfall: {
 			total: Math.round(targetYearStats.rain * 10) / 10,
-			wettestDay: {
-				date: time[wettestDayIdx],
-				value: Math.round(precipitation_sum[wettestDayIdx] * 10) / 10
-			},
+			wettestDay: targetYearStats.wettestDay,
 			historicalAverageTotal: Math.round(historicalAverageTotal * 10) / 10
 		},
 		sunshine: {
 			totalHours: Math.round(targetYearStats.sunshineHours * 10) / 10,
-			sunniestDay: {
-				date: time[sunniestDayIdx],
-				hours: Math.round((sunshine_duration[sunniestDayIdx] / 3600) * 10) / 10
-			},
+			sunniestDay: targetYearStats.sunniestDay,
 			historicalAverageHours: Math.round(historicalAverageHours * 10) / 10
 		},
 		temperatureRank,
 		headline: `${monthName} ${year} was the ${ordinal(temperatureRank)} warmest ${monthName} in Reading since ${EARLIEST_YEAR}`,
 		records: {
-			hottestDay,
-			coldestDay,
-			wettestDay
+			hottestDay: baseline.hottestDay,
+			coldestDay: baseline.coldestDay,
+			wettestDay: baseline.wettestDay
 		}
 	};
 }

--- a/src/lib/api/monthlySummary.ts
+++ b/src/lib/api/monthlySummary.ts
@@ -1,0 +1,231 @@
+import { toDateStr } from '$lib/dateUtils';
+
+const READING_LAT = 51.4543;
+const READING_LON = -0.9781;
+
+// ERA5 reanalysis coverage starts 1940-01-01.
+const EARLIEST_YEAR = 1940;
+
+// A single continuous-range request covering every year back to 1940 takes a few
+// seconds to generate upstream, so give it more headroom than the 7-day digest fetch.
+const REQUEST_TIMEOUT_MS = 15000;
+
+type OpenMeteoArchiveResponse = {
+	daily: {
+		time: string[];
+		temperature_2m_max: number[];
+		temperature_2m_min: number[];
+		temperature_2m_mean: number[];
+		precipitation_sum: number[];
+		sunshine_duration: number[];
+	};
+};
+
+export type DayRecord = {
+	date: string;
+	year: number;
+	value: number;
+};
+
+export type MonthlySummary = {
+	year: number;
+	month: number;
+	monthName: string;
+	label: string;
+	yearsOfData: number;
+	temperature: {
+		high: number;
+		low: number;
+		mean: number;
+		historicalAverageMean: number;
+	};
+	rainfall: {
+		total: number;
+		wettestDay: { date: string; value: number };
+		historicalAverageTotal: number;
+	};
+	sunshine: {
+		totalHours: number;
+		sunniestDay: { date: string; hours: number };
+		historicalAverageHours: number;
+	};
+	temperatureRank: number;
+	headline: string;
+	records: {
+		hottestDay: DayRecord;
+		coldestDay: DayRecord;
+		wettestDay: DayRecord;
+	};
+};
+
+type YearStats = {
+	year: number;
+	high: number;
+	low: number;
+	mean: number;
+	rain: number;
+	sunshineHours: number;
+};
+
+function monthBounds(year: number, month: number): { start: Date; end: Date } {
+	const start = new Date(Date.UTC(year, month - 1, 1));
+	const end = new Date(Date.UTC(year, month, 0));
+	return { start, end };
+}
+
+function ordinal(n: number): string {
+	const remainder100 = n % 100;
+	if (remainder100 >= 11 && remainder100 <= 13) return `${n}th`;
+	switch (n % 10) {
+		case 1:
+			return `${n}st`;
+		case 2:
+			return `${n}nd`;
+		case 3:
+			return `${n}rd`;
+		default:
+			return `${n}th`;
+	}
+}
+
+function indicesInRange(indexByDate: Map<string, number>, start: Date, end: Date): number[] {
+	const indices: number[] = [];
+	for (const d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+		const idx = indexByDate.get(toDateStr(d));
+		if (idx !== undefined) indices.push(idx);
+	}
+	return indices;
+}
+
+export async function fetchMonthlySummary(
+	year: number,
+	month: number,
+	now: Date = new Date()
+): Promise<MonthlySummary> {
+	const { start, end } = monthBounds(year, month);
+
+	const yesterday = new Date(now);
+	yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+	if (end > yesterday) {
+		throw new Error('Monthly summary is only available for fully completed months');
+	}
+
+	const rangeStart = new Date(Date.UTC(EARLIEST_YEAR, month - 1, 1));
+
+	const params = new URLSearchParams({
+		latitude: String(READING_LAT),
+		longitude: String(READING_LON),
+		start_date: toDateStr(rangeStart),
+		end_date: toDateStr(end),
+		daily:
+			'temperature_2m_max,temperature_2m_min,temperature_2m_mean,precipitation_sum,sunshine_duration',
+		timezone: 'Europe/London'
+	});
+
+	const response = await fetch(`https://archive-api.open-meteo.com/v1/archive?${params}`, {
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+	});
+	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
+
+	const data = (await response.json()) as OpenMeteoArchiveResponse;
+	const {
+		time,
+		temperature_2m_max,
+		temperature_2m_min,
+		temperature_2m_mean,
+		precipitation_sum,
+		sunshine_duration
+	} = data.daily;
+	const indexByDate = new Map(time.map((dateStr, i) => [dateStr, i]));
+
+	const yearStats: YearStats[] = [];
+	let hottestDay: DayRecord | null = null;
+	let coldestDay: DayRecord | null = null;
+	let wettestDay: DayRecord | null = null;
+
+	for (let y = EARLIEST_YEAR; y <= year; y++) {
+		const bounds = monthBounds(y, month);
+		const indices = indicesInRange(indexByDate, bounds.start, bounds.end);
+		if (indices.length === 0) continue;
+
+		const high = Math.max(...indices.map((i) => temperature_2m_max[i]));
+		const low = Math.min(...indices.map((i) => temperature_2m_min[i]));
+		const mean = indices.reduce((sum, i) => sum + temperature_2m_mean[i], 0) / indices.length;
+		const rain = indices.reduce((sum, i) => sum + precipitation_sum[i], 0);
+		const sunshineHours = indices.reduce((sum, i) => sum + sunshine_duration[i], 0) / 3600;
+		yearStats.push({ year: y, high, low, mean, rain, sunshineHours });
+
+		for (const i of indices) {
+			const date = time[i];
+			if (!hottestDay || temperature_2m_max[i] > hottestDay.value) {
+				hottestDay = { date, year: y, value: Math.round(temperature_2m_max[i] * 10) / 10 };
+			}
+			if (!coldestDay || temperature_2m_min[i] < coldestDay.value) {
+				coldestDay = { date, year: y, value: Math.round(temperature_2m_min[i] * 10) / 10 };
+			}
+			if (!wettestDay || precipitation_sum[i] > wettestDay.value) {
+				wettestDay = { date, year: y, value: Math.round(precipitation_sum[i] * 10) / 10 };
+			}
+		}
+	}
+
+	const targetYearStats = yearStats.find((s) => s.year === year);
+	if (!targetYearStats || !hottestDay || !coldestDay || !wettestDay) {
+		throw new Error('No historical data available for this month');
+	}
+
+	const historicalAverageMean = yearStats.reduce((sum, s) => sum + s.mean, 0) / yearStats.length;
+	const historicalAverageTotal = yearStats.reduce((sum, s) => sum + s.rain, 0) / yearStats.length;
+	const historicalAverageHours =
+		yearStats.reduce((sum, s) => sum + s.sunshineHours, 0) / yearStats.length;
+
+	const rankedByMean = [...yearStats].sort((a, b) => b.mean - a.mean);
+	const temperatureRank = rankedByMean.findIndex((s) => s.year === year) + 1;
+
+	const monthName = start.toLocaleDateString('en-GB', { month: 'long', timeZone: 'UTC' });
+
+	const targetIndices = indicesInRange(indexByDate, start, end);
+	let wettestDayIdx = targetIndices[0];
+	let sunniestDayIdx = targetIndices[0];
+	for (const i of targetIndices) {
+		if (precipitation_sum[i] > precipitation_sum[wettestDayIdx]) wettestDayIdx = i;
+		if (sunshine_duration[i] > sunshine_duration[sunniestDayIdx]) sunniestDayIdx = i;
+	}
+
+	return {
+		year,
+		month,
+		monthName,
+		label: `${monthName} ${year}`,
+		yearsOfData: yearStats.length,
+		temperature: {
+			high: Math.round(targetYearStats.high * 10) / 10,
+			low: Math.round(targetYearStats.low * 10) / 10,
+			mean: Math.round(targetYearStats.mean * 10) / 10,
+			historicalAverageMean: Math.round(historicalAverageMean * 10) / 10
+		},
+		rainfall: {
+			total: Math.round(targetYearStats.rain * 10) / 10,
+			wettestDay: {
+				date: time[wettestDayIdx],
+				value: Math.round(precipitation_sum[wettestDayIdx] * 10) / 10
+			},
+			historicalAverageTotal: Math.round(historicalAverageTotal * 10) / 10
+		},
+		sunshine: {
+			totalHours: Math.round(targetYearStats.sunshineHours * 10) / 10,
+			sunniestDay: {
+				date: time[sunniestDayIdx],
+				hours: Math.round((sunshine_duration[sunniestDayIdx] / 3600) * 10) / 10
+			},
+			historicalAverageHours: Math.round(historicalAverageHours * 10) / 10
+		},
+		temperatureRank,
+		headline: `${monthName} ${year} was the ${ordinal(temperatureRank)} warmest ${monthName} in Reading since ${EARLIEST_YEAR}`,
+		records: {
+			hottestDay,
+			coldestDay,
+			wettestDay
+		}
+	};
+}

--- a/src/lib/api/monthlySummary.ts
+++ b/src/lib/api/monthlySummary.ts
@@ -97,6 +97,25 @@ function indicesInRange(indexByDate: Map<string, number>, start: Date, end: Date
 	return indices;
 }
 
+// This full-range request is heavy enough (86 years of daily data across 5 variables)
+// that browsing between several months in quick succession can trip Open-Meteo's rate
+// limit. Retry a 429 a couple of times, honouring Retry-After when the upstream sends one,
+// rather than surfacing a spurious failure for what is otherwise a valid request.
+const MAX_ATTEMPTS = 3;
+
+async function fetchArchive(url: string): Promise<Response> {
+	let response: Response | undefined;
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+		if (response.status !== 429 || attempt === MAX_ATTEMPTS) return response;
+
+		const retryAfterSeconds = Number(response.headers.get('retry-after'));
+		const delayMs = retryAfterSeconds > 0 ? retryAfterSeconds * 1000 : attempt * 1000;
+		await new Promise((resolve) => setTimeout(resolve, delayMs));
+	}
+	return response as Response;
+}
+
 export async function fetchMonthlySummary(
 	year: number,
 	month: number,
@@ -122,9 +141,7 @@ export async function fetchMonthlySummary(
 		timezone: 'Europe/London'
 	});
 
-	const response = await fetch(`https://archive-api.open-meteo.com/v1/archive?${params}`, {
-		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
-	});
+	const response = await fetchArchive(`https://archive-api.open-meteo.com/v1/archive?${params}`);
 	if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
 
 	const data = (await response.json()) as OpenMeteoArchiveResponse;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -6,10 +6,22 @@ import GET_POSTS_ON_THIS_DAY from '$lib/graphql/queries/getPostsOnThisDay';
 import type { AllPostsResponse, LatestSeasonalPostResponse, OnThisDayResponse } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
+function lastCompletedMonth(now: Date): { year: number; month: number } {
+	const year = now.getUTCFullYear();
+	const month = now.getUTCMonth() + 1;
+	return month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+}
+
 export const load: PageServerLoad = async ({ fetch }) => {
 	const today = new Date();
 	const month = today.getMonth() + 1;
 	const day = today.getDate();
+
+	const last = lastCompletedMonth(today);
+	const lastMonthLabel = new Date(Date.UTC(last.year, last.month - 1, 1)).toLocaleDateString(
+		'en-GB',
+		{ month: 'long', year: 'numeric', timeZone: 'UTC' }
+	);
 
 	const [postsResult, latestSeasonalPost, onThisDay, historicalWeather] = await Promise.all([
 		fetchGraphQL<AllPostsResponse>(ALL_POSTS_QUERY, {}, fetch).catch(() => null),
@@ -35,6 +47,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		latestSeasonalPost: latestSeasonalPost?.posts?.nodes?.[0] ?? null,
 		onThisDay,
 		historicalWeather,
+		lastMonth: { ...last, label: lastMonthLabel },
 		meta
 	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -48,6 +48,14 @@
 
 <WeeklyDigest />
 
+{#if data.lastMonth}
+	<section class="monthly-summary-teaser">
+		<a href="/monthly-summary/{data.lastMonth.year}/{String(data.lastMonth.month).padStart(2, '0')}">
+			📅 {data.lastMonth.label} report card
+		</a>
+	</section>
+{/if}
+
 <WeekInHistory />
 
 <WeatherStreak />

--- a/src/routes/api/monthly-summary/+server.ts
+++ b/src/routes/api/monthly-summary/+server.ts
@@ -1,0 +1,39 @@
+import { json } from '@sveltejs/kit';
+import { fetchMonthlySummary, type MonthlySummary } from '$lib/api/monthlySummary';
+import { getCache, setCache } from '$lib/server/cache';
+import type { RequestHandler } from './$types';
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const ERROR_TTL_MS = 5 * 60 * 1000;
+
+export const GET: RequestHandler = async ({ url }) => {
+	const year = Number(url.searchParams.get('year'));
+	const month = Number(url.searchParams.get('month'));
+
+	if (!year || !month || month < 1 || month > 12) {
+		return json({ error: 'year and month are required' }, { status: 400 });
+	}
+
+	const cacheKey = `monthly-summary-${year}-${month}`;
+	const cached = getCache<MonthlySummary>(cacheKey);
+	if (cached) return json(cached);
+
+	const errorCacheKey = `${cacheKey}-error`;
+	if (getCache<true>(errorCacheKey)) {
+		return json({ error: 'Monthly summary temporarily unavailable' }, { status: 502 });
+	}
+
+	try {
+		const data = await fetchMonthlySummary(year, month);
+		setCache(cacheKey, data, TTL_MS);
+		return json(data);
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('fully completed months')) {
+			return json({ error: err.message }, { status: 400 });
+		}
+		// Avoid hammering an already-failing/rate-limited upstream on every request.
+		setCache(errorCacheKey, true, ERROR_TTL_MS);
+		console.error('fetchMonthlySummary failed:', err);
+		return json({ error: 'Monthly summary temporarily unavailable' }, { status: 502 });
+	}
+};

--- a/src/routes/api/monthly-summary/server.spec.ts
+++ b/src/routes/api/monthly-summary/server.spec.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn((key: string) => cacheStore.get(key) ?? null),
+	setCache: vi.fn((key: string, data: unknown) => {
+		cacheStore.set(key, data);
+	})
+}));
+
+const mockSummary = {
+	year: 2026,
+	month: 6,
+	monthName: 'June',
+	label: 'June 2026',
+	yearsOfData: 87,
+	temperature: { high: 28.5, low: 9.2, mean: 17.1, historicalAverageMean: 15.8 },
+	rainfall: {
+		total: 42.3,
+		wettestDay: { date: '2026-06-14', value: 18.2 },
+		historicalAverageTotal: 50.1
+	},
+	sunshine: {
+		totalHours: 210.4,
+		sunniestDay: { date: '2026-06-21', hours: 14.8 },
+		historicalAverageHours: 190.2
+	},
+	temperatureRank: 3,
+	headline: 'June 2026 was the 3rd warmest June in Reading since 1940',
+	records: {
+		hottestDay: { date: '2026-06-20', year: 2026, value: 32.1 },
+		coldestDay: { date: '1962-06-02', year: 1962, value: 1.2 },
+		wettestDay: { date: '1971-06-14', year: 1971, value: 40.5 }
+	}
+};
+
+vi.mock('$lib/api/monthlySummary', () => ({
+	fetchMonthlySummary: vi.fn()
+}));
+
+import { fetchMonthlySummary } from '$lib/api/monthlySummary';
+import { GET } from './+server';
+
+function makeEvent(params: Record<string, string> = {}) {
+	const url = new URL('http://localhost/api/monthly-summary');
+	for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+	return { url } as unknown as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+	cacheStore.clear();
+	vi.clearAllMocks();
+});
+
+describe('GET /api/monthly-summary', () => {
+	it('returns 400 when year or month is missing', async () => {
+		const response = await GET(makeEvent({ year: '2026' }));
+		expect(response.status).toBe(400);
+	});
+
+	it('returns 400 when month is out of range', async () => {
+		const response = await GET(makeEvent({ year: '2026', month: '13' }));
+		expect(response.status).toBe(400);
+	});
+
+	it('returns 200 with the monthly summary', async () => {
+		vi.mocked(fetchMonthlySummary).mockResolvedValue(mockSummary);
+
+		const response = await GET(makeEvent({ year: '2026', month: '6' }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.label).toBe('June 2026');
+		expect(body.temperatureRank).toBe(3);
+	});
+
+	it('returns 400 when the requested month is not yet complete', async () => {
+		vi.mocked(fetchMonthlySummary).mockRejectedValue(
+			new Error('Monthly summary is only available for fully completed months')
+		);
+
+		const response = await GET(makeEvent({ year: '2026', month: '7' }));
+
+		expect(response.status).toBe(400);
+	});
+
+	it('returns a 502 with an error body when the upstream fetch fails', async () => {
+		vi.mocked(fetchMonthlySummary).mockRejectedValue(new Error('Open-Meteo error: 429'));
+
+		const response = await GET(makeEvent({ year: '2026', month: '6' }));
+
+		expect(response.status).toBe(502);
+		const body = await response.json();
+		expect(body.error).toBeTruthy();
+	});
+
+	it('does not call the upstream again while a recent failure is cached', async () => {
+		vi.mocked(fetchMonthlySummary).mockRejectedValue(new Error('Open-Meteo error: 429'));
+		await GET(makeEvent({ year: '2026', month: '6' }));
+
+		vi.mocked(fetchMonthlySummary).mockClear();
+		const response = await GET(makeEvent({ year: '2026', month: '6' }));
+
+		expect(response.status).toBe(502);
+		expect(fetchMonthlySummary).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/monthly-summary/+page.server.ts
+++ b/src/routes/monthly-summary/+page.server.ts
@@ -1,0 +1,29 @@
+import type { PageServerLoad } from './$types';
+
+// Monthly report cards are only offered from the site's launch year onward,
+// even though the underlying ERA5 data goes back to 1940.
+const START_YEAR = 2020;
+
+type MonthEntry = { year: number; month: number };
+
+function lastCompletedMonth(now: Date): MonthEntry {
+	const year = now.getUTCFullYear();
+	const month = now.getUTCMonth() + 1;
+	return month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+}
+
+export const load: PageServerLoad = async ({ setHeaders }) => {
+	const last = lastCompletedMonth(new Date());
+
+	const months: MonthEntry[] = [];
+	for (let year = last.year; year >= START_YEAR; year--) {
+		const firstMonth = year === last.year ? last.month : 12;
+		for (let month = firstMonth; month >= 1; month--) {
+			months.push({ year, month });
+		}
+	}
+
+	setHeaders({ 'cache-control': 'public, max-age=3600' });
+
+	return { months };
+};

--- a/src/routes/monthly-summary/+page.svelte
+++ b/src/routes/monthly-summary/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { PageProps } from './$types';
+
+	const { data }: PageProps = $props();
+
+	const MONTH_NAMES = [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December'
+	];
+</script>
+
+<svelte:head>
+	<title>Monthly Weather Report Cards | Reading Weather</title>
+	<meta
+		name="description"
+		content="Browse monthly weather report cards for Reading, comparing each month's temperature, rainfall and sunshine against the historical average."
+	/>
+</svelte:head>
+
+<h1>Monthly Weather Report Cards</h1>
+
+<ul class="monthly-summary-index">
+	{#each data.months as { year, month } (`${year}-${month}`)}
+		<li>
+			<a href="/monthly-summary/{year}/{String(month).padStart(2, '0')}">
+				{MONTH_NAMES[month - 1]} {year}
+			</a>
+		</li>
+	{/each}
+</ul>

--- a/src/routes/monthly-summary/[year]/[month]/+page.server.ts
+++ b/src/routes/monthly-summary/[year]/[month]/+page.server.ts
@@ -1,0 +1,25 @@
+import { error } from '@sveltejs/kit';
+import type { MonthlySummary } from '$lib/api/monthlySummary';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
+	const year = Number(params.year);
+	const month = Number(params.month);
+
+	if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) {
+		throw error(404, 'Monthly summary not found');
+	}
+
+	const response = await fetch(`/api/monthly-summary?year=${year}&month=${month}`);
+	if (!response.ok) {
+		throw error(404, 'Monthly summary not found');
+	}
+
+	const summary = (await response.json()) as MonthlySummary;
+
+	// A page that loads successfully only ever describes a fully completed past
+	// month, so its content never changes again once published.
+	setHeaders({ 'cache-control': 'public, max-age=31536000, immutable' });
+
+	return { summary };
+};

--- a/src/routes/monthly-summary/[year]/[month]/+page.server.ts
+++ b/src/routes/monthly-summary/[year]/[month]/+page.server.ts
@@ -12,6 +12,9 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
 
 	const response = await fetch(`/api/monthly-summary?year=${year}&month=${month}`);
 	if (!response.ok) {
+		if (response.status === 502) {
+			throw error(503, 'This report is temporarily unavailable — please try again in a few minutes.');
+		}
 		throw error(404, 'Monthly summary not found');
 	}
 

--- a/src/routes/monthly-summary/[year]/[month]/+page.svelte
+++ b/src/routes/monthly-summary/[year]/[month]/+page.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import type { PageProps } from './$types';
+
+	const { data }: PageProps = $props();
+
+	const { summary } = data;
+
+	function formatDate(dateStr: string): string {
+		return new Date(dateStr).toLocaleDateString('en-GB', {
+			weekday: 'long',
+			day: 'numeric',
+			month: 'long',
+			timeZone: 'UTC'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>{summary.label} Weather Report Card | Reading Weather</title>
+	<meta name="description" content={summary.headline} />
+	<meta property="og:title" content="{summary.label} Weather Report Card" />
+	<meta property="og:description" content={summary.headline} />
+</svelte:head>
+
+<h1>{summary.label} Weather Report Card</h1>
+
+<section class="monthly-summary-card">
+	<p class="headline">{summary.headline}</p>
+
+	<div class="stat-group">
+		<h2>Temperature</h2>
+		<p>
+			High: <strong>{summary.temperature.high}°C</strong> · Low: <strong
+				>{summary.temperature.low}°C</strong
+			>
+		</p>
+		<p>
+			Mean: <strong>{summary.temperature.mean}°C</strong> (average for {summary.monthName}: {summary
+				.temperature.historicalAverageMean}°C)
+		</p>
+	</div>
+
+	<div class="stat-group">
+		<h2>Rainfall</h2>
+		<p>
+			Total: <strong>{summary.rainfall.total}mm</strong> (average: {summary.rainfall
+				.historicalAverageTotal}mm)
+		</p>
+		<p>
+			Wettest day: {formatDate(summary.rainfall.wettestDay.date)} ({summary.rainfall.wettestDay
+				.value}mm)
+		</p>
+	</div>
+
+	<div class="stat-group">
+		<h2>Sunshine</h2>
+		<p>
+			Total: <strong>{summary.sunshine.totalHours}h</strong> (average: {summary.sunshine
+				.historicalAverageHours}h)
+		</p>
+		<p>
+			Sunniest day: {formatDate(summary.sunshine.sunniestDay.date)} ({summary.sunshine.sunniestDay
+				.hours}h sun)
+		</p>
+	</div>
+
+	<div class="stat-group">
+		<h2>Notable days</h2>
+		<p class="range">{summary.yearsOfData} years of records</p>
+		<ul class="records">
+			<li>
+				<span aria-hidden="true">🌡️</span> Hottest day: <strong
+					>{summary.records.hottestDay.value}°C</strong
+				>
+				— {formatDate(summary.records.hottestDay.date)}, {summary.records.hottestDay.year}
+				{#if summary.records.hottestDay.year === summary.year}
+					<span class="new-record">New record</span>
+				{/if}
+			</li>
+			<li>
+				<span aria-hidden="true">❄️</span> Coldest day: <strong
+					>{summary.records.coldestDay.value}°C</strong
+				>
+				— {formatDate(summary.records.coldestDay.date)}, {summary.records.coldestDay.year}
+				{#if summary.records.coldestDay.year === summary.year}
+					<span class="new-record">New record</span>
+				{/if}
+			</li>
+			<li>
+				<span aria-hidden="true">🌧️</span> Wettest day: <strong
+					>{summary.records.wettestDay.value}mm</strong
+				>
+				— {formatDate(summary.records.wettestDay.date)}, {summary.records.wettestDay.year}
+				{#if summary.records.wettestDay.year === summary.year}
+					<span class="new-record">New record</span>
+				{/if}
+			</li>
+		</ul>
+	</div>
+
+	<p class="conditions-note">
+		Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
+		approximate guide only
+	</p>
+</section>
+
+<p class="older-posts">
+	<a href="/monthly-summary">Browse all monthly report cards</a>
+</p>

--- a/src/routes/monthly-summary/[year]/[month]/page.spec.ts
+++ b/src/routes/monthly-summary/[year]/[month]/page.spec.ts
@@ -63,4 +63,11 @@ describe('monthly-summary/[year]/[month] load', () => {
 
 		await expect(load(event)).rejects.toMatchObject({ status: 404 });
 	});
+
+	it('throws a 503 when the API reports the upstream is temporarily unavailable', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
+		const event = makeEvent({ year: '2026', month: '07' }, mockFetch);
+
+		await expect(load(event)).rejects.toMatchObject({ status: 503 });
+	});
 });

--- a/src/routes/monthly-summary/[year]/[month]/page.spec.ts
+++ b/src/routes/monthly-summary/[year]/[month]/page.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { load } from './+page.server';
+
+const mockSummary = {
+	year: 2026,
+	month: 6,
+	monthName: 'June',
+	label: 'June 2026',
+	yearsOfData: 87,
+	temperature: { high: 28.5, low: 9.2, mean: 17.1, historicalAverageMean: 15.8 },
+	rainfall: {
+		total: 42.3,
+		wettestDay: { date: '2026-06-14', value: 18.2 },
+		historicalAverageTotal: 50.1
+	},
+	sunshine: {
+		totalHours: 210.4,
+		sunniestDay: { date: '2026-06-21', hours: 14.8 },
+		historicalAverageHours: 190.2
+	},
+	temperatureRank: 3,
+	headline: 'June 2026 was the 3rd warmest June in Reading since 1940',
+	records: {
+		hottestDay: { date: '2026-06-20', year: 2026, value: 32.1 },
+		coldestDay: { date: '1962-06-02', year: 1962, value: 1.2 },
+		wettestDay: { date: '1971-06-14', year: 1971, value: 40.5 }
+	}
+};
+
+function makeEvent(params: Record<string, string>, fetchImpl: typeof fetch) {
+	return {
+		params,
+		fetch: fetchImpl,
+		setHeaders: vi.fn()
+	} as unknown as Parameters<typeof load>[0];
+}
+
+describe('monthly-summary/[year]/[month] load', () => {
+	it('loads the summary from the API and sets an immutable cache header', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mockSummary });
+		const event = makeEvent({ year: '2026', month: '06' }, mockFetch);
+
+		const result = await load(event);
+
+		expect(result).toEqual({ summary: mockSummary });
+		expect(mockFetch).toHaveBeenCalledWith('/api/monthly-summary?year=2026&month=6');
+		expect(event.setHeaders).toHaveBeenCalledWith({
+			'cache-control': 'public, max-age=31536000, immutable'
+		});
+	});
+
+	it('throws a 404 when the month param is out of range', async () => {
+		const mockFetch = vi.fn();
+		const event = makeEvent({ year: '2026', month: '13' }, mockFetch);
+
+		await expect(load(event)).rejects.toMatchObject({ status: 404 });
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it('throws a 404 when the API responds with an error', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+		const event = makeEvent({ year: '2026', month: '07' }, mockFetch);
+
+		await expect(load(event)).rejects.toMatchObject({ status: 404 });
+	});
+});

--- a/src/routes/monthly-summary/page.spec.ts
+++ b/src/routes/monthly-summary/page.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { load } from './+page.server';
+
+type MonthEntry = { year: number; month: number };
+type LoadResult = { months: MonthEntry[] };
+
+function makeEvent() {
+	return { setHeaders: vi.fn() } as unknown as Parameters<typeof load>[0];
+}
+
+describe('monthly-summary index load', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('lists months newest first, ending at the last fully completed month', async () => {
+		vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+
+		const result = (await load(makeEvent())) as LoadResult;
+
+		expect(result.months[0]).toEqual({ year: 2026, month: 6 });
+		expect(result.months[1]).toEqual({ year: 2026, month: 5 });
+	});
+
+	it('rolls over into December of the previous year when the current month is January', async () => {
+		vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+
+		const result = (await load(makeEvent())) as LoadResult;
+
+		expect(result.months[0]).toEqual({ year: 2025, month: 12 });
+	});
+
+	it('goes back only as far as the start year', async () => {
+		vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+
+		const result = (await load(makeEvent())) as LoadResult;
+
+		expect(result.months[result.months.length - 1]).toEqual({ year: 2020, month: 1 });
+	});
+});

--- a/src/routes/page.spec.ts
+++ b/src/routes/page.spec.ts
@@ -94,6 +94,23 @@ describe('home page load', () => {
 		expect(result.latestSeasonalPost).toBeNull();
 	});
 
+	it('returns lastMonth as the previous calendar month', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+		vi.mocked(fetchGraphQL)
+			.mockResolvedValueOnce(mockPosts)
+			.mockResolvedValueOnce(mockSeasonalResponse)
+			.mockResolvedValueOnce(mockOnThisDay);
+
+		const result = (await load({
+			setHeaders: vi.fn(),
+			fetch: mockFetch
+		} as unknown as Parameters<typeof load>[0])) as LoadResult;
+
+		expect(result.lastMonth).toEqual({ year: 2026, month: 6, label: 'June 2026' });
+		vi.useRealTimers();
+	});
+
 	it('returns null for onThisDay when that fetch fails', async () => {
 		vi.mocked(fetchGraphQL)
 			.mockResolvedValueOnce(mockPosts)

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -295,7 +295,6 @@ main {
 	.stat-group {
 		margin: 0 0 1rem;
 
-		/* biome-ignore lint/style/noDescendingSpecificity: targets .stat-group h2, unrelated to main .post h2 */
 		h2 {
 			margin: 0 0 0.5rem;
 			font-size: 1.1rem;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -267,6 +267,85 @@ main {
 	}
 }
 
+.monthly-summary-teaser {
+	border: 5px solid var(--nav);
+	margin-bottom: 2rem;
+	padding: 1rem;
+	text-align: center;
+	background: var(--white);
+
+	a {
+		font-size: 1.125rem;
+	}
+}
+
+.monthly-summary-card {
+	border: 5px solid var(--nav);
+	margin-bottom: 2rem;
+	padding: 1rem;
+	text-align: center;
+	background: var(--white);
+
+	.headline {
+		font-size: 1.1rem;
+		font-weight: 600;
+		margin: 0 0 1rem;
+	}
+
+	.stat-group {
+		margin: 0 0 1rem;
+
+		/* biome-ignore lint/style/noDescendingSpecificity: targets .stat-group h2, unrelated to main .post h2 */
+		h2 {
+			margin: 0 0 0.5rem;
+			font-size: 1.1rem;
+		}
+
+		p {
+			margin: 0 0 0.35rem;
+		}
+	}
+
+	.range {
+		margin: 0 0 0.5rem;
+		font-size: 0.85rem;
+		color: #767676;
+	}
+
+	.records {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		font-size: 1.05rem;
+	}
+
+	.new-record {
+		color: var(--nav);
+		font-weight: 600;
+	}
+
+	.conditions-note {
+		font-size: 0.8rem;
+		color: #767676;
+		margin: 0.75rem 0 0;
+		font-style: italic;
+	}
+}
+
+.monthly-summary-index {
+	list-style: none;
+	padding: 0;
+	max-width: 400px;
+	margin: 0 auto 2rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	text-align: center;
+}
+
 .older-posts {
 	text-align: center;
 	margin: 0 0 2rem 0;


### PR DESCRIPTION
## Summary
- Implements the core of #413: a Monthly Weather Report Card feature, comparing each calendar month against ERA5 historical data back to 1940.
- **Not included**: the email subscribe CTA described in the issue — deliberately left out per request.

## What's new
- `src/lib/api/monthlySummary.ts` — fetches a single continuous ERA5 range (same pattern as `weekInHistory.ts`) and computes, for the requested month/year: temperature high/low/mean vs. the historical average, total rainfall + wettest day vs. average, total sunshine hours + sunniest day vs. average, a "Nth warmest since 1940" ranking, and all-time hottest/coldest/wettest day records (flagging when the requested month itself set a new one).
- `GET /api/monthly-summary?year=&month=` — cached API route; 400 for an incomplete/future month, 502 with a short error cache on upstream failure.
- `/monthly-summary/[year]/[month]` — the report card page. Cached with a long, immutable `Cache-Control` header since a completed month's data never changes.
- `/monthly-summary` — index page listing all months since 2020, newest first.
- Homepage — a "📅 [Month Year] report card" teaser card below the weekly digest, linking to last month's page.
- Matching CSS for all new sections, styled consistently with the existing weekly-digest/week-in-history cards.

## Test plan
- [x] `yarn test:unit` — 171 tests passing, including 21 new tests covering the calculation logic, API route, and both page loads
- [x] `yarn check` — no type errors
- [ ] Manually spot-check `/monthly-summary` and a `/monthly-summary/[year]/[month]` page in a browser