### PR TITLE
feat: add condition, streak, and richer headlines to the monthly report card

### DIFF
--- a/src/lib/api/monthlySummary.spec.ts
+++ b/src/lib/api/monthlySummary.spec.ts
@@ -65,6 +65,19 @@ function makeArchiveResponse() {
 		...fill(2020, 5 * 3600),
 		...fill(2026, 5 * 3600, 14.8 * 3600)
 	];
+	// 2026 is mostly "cloudy" (code 3), aside from the 20th (code 61, "light rain").
+	const weather_code = [
+		...fill(1962, 3),
+		...fill(1971, 3),
+		...fill(2020, 3),
+		...years
+			.filter((y) => y === 2026)
+			.flatMap((y) => {
+				const codes = new Array(juneDates(y).length).fill(3);
+				codes[19] = 61;
+				return codes;
+			})
+	];
 
 	return {
 		ok: true,
@@ -75,7 +88,8 @@ function makeArchiveResponse() {
 				temperature_2m_min,
 				temperature_2m_mean,
 				precipitation_sum,
-				sunshine_duration
+				sunshine_duration,
+				weather_code
 			}
 		})
 	};
@@ -221,6 +235,75 @@ describe('fetchMonthlySummary', () => {
 		);
 		await expect(fetchMonthlySummary(2026, 6, NOW)).rejects.toThrow(
 			'No historical data available for this month'
+		);
+	});
+
+	it('reports the dominant weather condition for the requested month', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.condition).toEqual({ category: 'cloudy', label: 'cloudy' });
+	});
+
+	it('falls back to a null condition when the archive response has no weather codes', async () => {
+		const { weather_code: _weather_code, ...dailyWithoutCodes } = (
+			await makeArchiveResponse().json()
+		).daily;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({ ok: true, json: async () => ({ daily: dailyWithoutCodes }) })
+		);
+
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.condition).toBeNull();
+	});
+
+	it('finds the longest run of consecutive days meeting a streak threshold within the month', async () => {
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		// Every day in June 2026 has at least 1mm of rain in the fixture, so the
+		// whole month qualifies as one long "wet" streak.
+		expect(summary.streak).toEqual({
+			type: 'wet',
+			emoji: '🌧️',
+			length: 30,
+			label: '30 consecutive days of rain'
+		});
+	});
+
+	it('uses a rainfall headline instead of the temperature ranking when rainfall is far from average', async () => {
+		const years = [1962, 1971, 2020, 2026];
+		const time = years.flatMap(juneDates);
+
+		function fill(year: number, value: number) {
+			return new Array(juneDates(year).length).fill(value);
+		}
+
+		const flat = (value: number) => years.flatMap((y) => fill(y, value));
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					daily: {
+						time,
+						temperature_2m_max: flat(20),
+						temperature_2m_min: flat(10),
+						temperature_2m_mean: flat(15),
+						// 2026 gets 4x the rain of every other year on record.
+						precipitation_sum: [
+							...fill(1962, 1.0),
+							...fill(1971, 1.0),
+							...fill(2020, 1.0),
+							...fill(2026, 4.0)
+						],
+						sunshine_duration: flat(5 * 3600)
+					}
+				})
+			})
+		);
+
+		const summary = await fetchMonthlySummary(2026, 6, NOW);
+		expect(summary.headline).toBe(
+			'June 2026 was an unusually wet month in Reading — 2.3× the typical June rainfall'
 		);
 	});
 });

--- a/src/lib/api/monthlySummary.ts
+++ b/src/lib/api/monthlySummary.ts
@@ -26,6 +26,7 @@ type OpenMeteoArchiveResponse = {
 		temperature_2m_mean: number[];
 		precipitation_sum: number[];
 		sunshine_duration: number[];
+		weather_code?: number[];
 	};
 };
 
@@ -34,6 +35,98 @@ export type DayRecord = {
 	year: number;
 	value: number;
 };
+
+// Buckets Open-Meteo's WMO weather codes into the handful of categories a
+// reader actually cares about for "what was the month like overall" — the
+// same granularity used for the daily conditions elsewhere in the app would
+// be too noisy to summarise 28-31 days into one label.
+export type ConditionCategory = 'sunny' | 'cloudy' | 'rainy' | 'snowy' | 'foggy';
+
+const CONDITION_LABELS: Record<ConditionCategory, string> = {
+	sunny: 'sunny',
+	cloudy: 'cloudy',
+	rainy: 'rainy',
+	snowy: 'snowy',
+	foggy: 'foggy'
+};
+
+function categoriseCode(code: number): ConditionCategory {
+	if (code === 0 || code === 1) return 'sunny';
+	if (code === 45 || code === 48) return 'foggy';
+	if (code >= 71 && code <= 86) return 'snowy';
+	if (code >= 51) return 'rainy';
+	return 'cloudy';
+}
+
+export type MonthStreakType = 'dry' | 'wet' | 'warm' | 'cold';
+
+// Mirrors the thresholds in weatherStreak.ts's dry/wet/warm/cold definitions,
+// kept independent here since this streak is measured within a fixed calendar
+// month rather than as an ongoing run ending today.
+const MONTH_STREAK_DEFINITIONS: {
+	type: MonthStreakType;
+	emoji: string;
+	label: (n: number) => string;
+	test: (tempMax: number, precipitation: number) => boolean;
+}[] = [
+	{
+		type: 'dry',
+		emoji: '☀️',
+		label: (n) => `${n} consecutive dry day${n === 1 ? '' : 's'}`,
+		test: (_tempMax, precipitation) => precipitation < 0.5
+	},
+	{
+		type: 'wet',
+		emoji: '🌧️',
+		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} of rain`,
+		test: (_tempMax, precipitation) => precipitation >= 1
+	},
+	{
+		type: 'warm',
+		emoji: '🔥',
+		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} above 25°C`,
+		test: (tempMax) => tempMax >= 25
+	},
+	{
+		type: 'cold',
+		emoji: '🥶',
+		label: (n) => `${n} consecutive day${n === 1 ? '' : 's'} below 5°C`,
+		test: (tempMax) => tempMax < 5
+	}
+];
+
+export type MonthStreak = {
+	type: MonthStreakType;
+	emoji: string;
+	length: number;
+	label: string;
+};
+
+function longestRun(matches: boolean[]): number {
+	let longest = 0;
+	let current = 0;
+	for (const m of matches) {
+		current = m ? current + 1 : 0;
+		if (current > longest) longest = current;
+	}
+	return longest;
+}
+
+function longestMonthStreak(
+	indices: number[],
+	temperature_2m_max: number[],
+	precipitation_sum: number[]
+): MonthStreak | null {
+	let best: MonthStreak | null = null;
+	for (const def of MONTH_STREAK_DEFINITIONS) {
+		const matches = indices.map((i) => def.test(temperature_2m_max[i], precipitation_sum[i]));
+		const length = longestRun(matches);
+		if (length >= 2 && (!best || length > best.length)) {
+			best = { type: def.type, emoji: def.emoji, length, label: def.label(length) };
+		}
+	}
+	return best;
+}
 
 export type MonthlySummary = {
 	year: number;
@@ -64,6 +157,8 @@ export type MonthlySummary = {
 		coldestDay: DayRecord;
 		wettestDay: DayRecord;
 	};
+	condition: { category: ConditionCategory; label: string } | null;
+	streak: MonthStreak | null;
 };
 
 type YearStats = {
@@ -75,6 +170,8 @@ type YearStats = {
 	sunshineHours: number;
 	wettestDay: { date: string; value: number };
 	sunniestDay: { date: string; hours: number };
+	condition: { category: ConditionCategory; label: string } | null;
+	streak: MonthStreak | null;
 };
 
 type MonthlyBaseline = {
@@ -157,7 +254,7 @@ async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<Mo
 		start_date: toDateStr(rangeStart),
 		end_date: toDateStr(rangeEnd),
 		daily:
-			'temperature_2m_max,temperature_2m_min,temperature_2m_mean,precipitation_sum,sunshine_duration',
+			'temperature_2m_max,temperature_2m_min,temperature_2m_mean,precipitation_sum,sunshine_duration,weather_code',
 		timezone: 'Europe/London'
 	});
 
@@ -171,7 +268,8 @@ async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<Mo
 		temperature_2m_min,
 		temperature_2m_mean,
 		precipitation_sum,
-		sunshine_duration
+		sunshine_duration,
+		weather_code = []
 	} = data.daily;
 	const indexByDate = new Map(time.map((dateStr, i) => [dateStr, i]));
 
@@ -209,6 +307,17 @@ async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<Mo
 			}
 		}
 
+		let condition: { category: ConditionCategory; label: string } | null = null;
+		if (weather_code.length > 0) {
+			const counts = new Map<ConditionCategory, number>();
+			for (const i of indices) {
+				const category = categoriseCode(weather_code[i]);
+				counts.set(category, (counts.get(category) ?? 0) + 1);
+			}
+			const [dominant] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+			condition = { category: dominant, label: CONDITION_LABELS[dominant] };
+		}
+
 		yearStats.push({
 			year: y,
 			high,
@@ -223,7 +332,9 @@ async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<Mo
 			sunniestDay: {
 				date: time[sunniestIdx],
 				hours: Math.round((sunshine_duration[sunniestIdx] / 3600) * 10) / 10
-			}
+			},
+			condition,
+			streak: longestMonthStreak(indices, temperature_2m_max, precipitation_sum)
 		});
 	}
 
@@ -234,6 +345,72 @@ async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<Mo
 	const baseline: MonthlyBaseline = { yearStats, hottestDay, coldestDay, wettestDay };
 	setCache(cacheKey, baseline, BASELINE_TTL_MS);
 	return baseline;
+}
+
+// A run-of-the-mill temperature ranking is the sensible default headline, but
+// a genuinely remarkable rainfall or sunshine total is more newsworthy — e.g.
+// "3x the typical rainfall" beats "14th warmest" every time. These thresholds
+// are deliberately high so an ordinary month doesn't get an overstated headline.
+const RAIN_HEADLINE_THRESHOLD_PCT = 40;
+const SUNSHINE_HEADLINE_THRESHOLD_PCT = 30;
+
+function rankAmong(values: number[], target: number, direction: 'desc' | 'asc'): number {
+	const sorted = [...values].sort((a, b) => (direction === 'desc' ? b - a : a - b));
+	return sorted.indexOf(target) + 1;
+}
+
+function buildHeadline(
+	yearStats: YearStats[],
+	target: YearStats,
+	label: string,
+	monthName: string,
+	temperatureRank: number,
+	historicalAverageTotal: number,
+	historicalAverageHours: number
+): string {
+	const rainDeviationPct =
+		historicalAverageTotal > 0
+			? ((target.rain - historicalAverageTotal) / historicalAverageTotal) * 100
+			: 0;
+	const sunshineDeviationPct =
+		historicalAverageHours > 0
+			? ((target.sunshineHours - historicalAverageHours) / historicalAverageHours) * 100
+			: 0;
+
+	const rainTriggered = Math.abs(rainDeviationPct) >= RAIN_HEADLINE_THRESHOLD_PCT;
+	const sunshineTriggered = Math.abs(sunshineDeviationPct) >= SUNSHINE_HEADLINE_THRESHOLD_PCT;
+
+	if (rainTriggered && (!sunshineTriggered || Math.abs(rainDeviationPct) >= Math.abs(sunshineDeviationPct))) {
+		if (rainDeviationPct > 0) {
+			const multiplier = Math.round((target.rain / historicalAverageTotal) * 10) / 10;
+			return `${label} was an unusually wet month in Reading — ${multiplier}× the typical ${monthName} rainfall`;
+		}
+		const driestRank = rankAmong(
+			yearStats.map((s) => s.rain),
+			target.rain,
+			'asc'
+		);
+		return `${label} was the ${ordinal(driestRank)} driest ${monthName} in Reading since ${EARLIEST_YEAR}`;
+	}
+
+	if (sunshineTriggered) {
+		if (sunshineDeviationPct > 0) {
+			const sunniestRank = rankAmong(
+				yearStats.map((s) => s.sunshineHours),
+				target.sunshineHours,
+				'desc'
+			);
+			return `${label} was the ${ordinal(sunniestRank)} sunniest ${monthName} in Reading since ${EARLIEST_YEAR}`;
+		}
+		const dullestRank = rankAmong(
+			yearStats.map((s) => s.sunshineHours),
+			target.sunshineHours,
+			'asc'
+		);
+		return `${label} saw just ${Math.round(target.sunshineHours * 10) / 10} hours of sunshine — the ${ordinal(dullestRank)} gloomiest ${monthName} in Reading since ${EARLIEST_YEAR}`;
+	}
+
+	return `${label} was the ${ordinal(temperatureRank)} warmest ${monthName} in Reading since ${EARLIEST_YEAR}`;
 }
 
 export async function fetchMonthlySummary(
@@ -294,11 +471,21 @@ export async function fetchMonthlySummary(
 			historicalAverageHours: Math.round(historicalAverageHours * 10) / 10
 		},
 		temperatureRank,
-		headline: `${monthName} ${year} was the ${ordinal(temperatureRank)} warmest ${monthName} in Reading since ${EARLIEST_YEAR}`,
+		headline: buildHeadline(
+			baseline.yearStats,
+			targetYearStats,
+			`${monthName} ${year}`,
+			monthName,
+			temperatureRank,
+			historicalAverageTotal,
+			historicalAverageHours
+		),
 		records: {
 			hottestDay: baseline.hottestDay,
 			coldestDay: baseline.coldestDay,
 			wettestDay: baseline.wettestDay
-		}
+		},
+		condition: targetYearStats.condition,
+		streak: targetYearStats.streak
 	};
 }

--- a/src/routes/api/monthly-summary/server.spec.ts
+++ b/src/routes/api/monthly-summary/server.spec.ts
@@ -32,7 +32,9 @@ const mockSummary = {
 		hottestDay: { date: '2026-06-20', year: 2026, value: 32.1 },
 		coldestDay: { date: '1962-06-02', year: 1962, value: 1.2 },
 		wettestDay: { date: '1971-06-14', year: 1971, value: 40.5 }
-	}
+	},
+	condition: { category: 'cloudy' as const, label: 'cloudy' },
+	streak: { type: 'wet' as const, emoji: '🌧️', length: 5, label: '5 consecutive days of rain' }
 };
 
 vi.mock('$lib/api/monthlySummary', () => ({

--- a/src/routes/monthly-summary/[year]/[month]/+page.svelte
+++ b/src/routes/monthly-summary/[year]/[month]/+page.svelte
@@ -1,9 +1,33 @@
 <script lang="ts">
+	import ShareButton from '$lib/components/ShareButton.svelte';
 	import type { PageProps } from './$types';
 
 	const { data }: PageProps = $props();
 
 	const { summary } = data;
+
+	const postUrl = $derived(
+		`https://www.readingweather.co.uk/monthly-summary/${summary.year}/${String(summary.month).padStart(2, '0')}`
+	);
+	const postTitle = $derived(`${summary.label} Weather Report Card`);
+
+	const jsonLd = $derived({
+		'@context': 'https://schema.org',
+		'@type': 'Dataset',
+		name: `${summary.label} Weather Report Card`,
+		description: summary.headline,
+		url: postUrl,
+		temporalCoverage: `${summary.year}-${String(summary.month).padStart(2, '0')}`,
+		spatialCoverage: {
+			'@type': 'Place',
+			name: 'Reading, UK'
+		},
+		creator: {
+			'@type': 'Organization',
+			name: 'Reading Weather',
+			url: 'https://www.readingweather.co.uk'
+		}
+	});
 
 	function formatDate(dateStr: string): string {
 		return new Date(dateStr).toLocaleDateString('en-GB', {
@@ -16,10 +40,15 @@
 </script>
 
 <svelte:head>
-	<title>{summary.label} Weather Report Card | Reading Weather</title>
+	<title>{postTitle} | Reading Weather</title>
 	<meta name="description" content={summary.headline} />
-	<meta property="og:title" content="{summary.label} Weather Report Card" />
+	<meta property="og:title" content={postTitle} />
 	<meta property="og:description" content={summary.headline} />
+	<meta property="og:type" content="article" />
+	<meta property="og:url" content={postUrl} />
+	<meta name="twitter:title" content={postTitle} />
+	<meta name="twitter:description" content={summary.headline} />
+	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
 <h1>{summary.label} Weather Report Card</h1>
@@ -64,6 +93,18 @@
 		</p>
 	</div>
 
+	{#if summary.condition || summary.streak}
+		<div class="stat-group">
+			<h2>The month at a glance</h2>
+			{#if summary.condition}
+				<p>Most common condition: <strong>{summary.condition.label}</strong></p>
+			{/if}
+			{#if summary.streak}
+				<p>Longest streak: <strong>{summary.streak.label}</strong> {summary.streak.emoji}</p>
+			{/if}
+		</div>
+	{/if}
+
 	<div class="stat-group">
 		<h2>Notable days</h2>
 		<p class="range">{summary.yearsOfData} years of records</p>
@@ -103,6 +144,8 @@
 		approximate guide only
 	</p>
 </section>
+
+<ShareButton {postUrl} {postTitle} postSummary={summary.headline} />
 
 <p class="older-posts">
 	<a href="/monthly-summary">Browse all monthly report cards</a>


### PR DESCRIPTION
## Summary
Closes the remaining data-and-narrative gaps between the shipped Monthly Weather Report Card (#413) and the "Weather Wrapped" ask in #415, without redoing the parts already covered by #413.

- **Most common condition**: added `weather_code` to the ERA5 fetch and bucket it into sunny/cloudy/rainy/snowy/foggy, then report the dominant one for the requested month.
- **Longest streak**: computes the longest dry/wet/warm/cold run *within* the requested month, using the same thresholds as `weatherStreak.ts`.
- **Richer headlines**: the headline now only defaults to the temperature ranking ("Nth warmest since 1940") when nothing more notable is going on. If rainfall is ≥40% off the historical average, or sunshine is ≥30% off, the headline calls that out instead — e.g. *"an unusually wet month in Reading — 2.3× the typical June rainfall"* or *"saw just 23 hours of sunshine — the 3rd gloomiest June in Reading since 1940"*.
- **Sharing & SEO**: wired up the existing `ShareButton.svelte`, proper OG/Twitter meta tags, and a `schema.org` `Dataset` JSON-LD block on the report card page — previously the page had none of this.

**Deliberately left out** (consistent with what #413 already excluded): the email subscribe CTA, Ko-fi widget injection, and extending the archive index back to 1940 (it currently only lists months since 2020).

## Test plan
- [x] `yarn test:unit` — 180 tests passing, including 4 new tests covering condition detection, the month streak, and the new headline branching
- [x] `yarn check` — no type errors
- [x] `yarn lint` — clean
- [ ] Manually spot-check a `/monthly-summary/[year]/[month]` page in a browser