### PR TITLE
chore(types): reduce inline type duplication and fix Svelte 5 reactivity warning

### DIFF
--- a/src/lib/components/OnThisDay.svelte
+++ b/src/lib/components/OnThisDay.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
 	import type { DailyWeather } from '$lib/api/historicalWeather';
-
-	type OnThisDayPost = {
-		title: string;
-		slug: string;
-		date: string;
-	};
+	import type { OnThisDayPost } from '$lib/types';
 
 	type Props = {
 		posts: OnThisDayPost[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,10 +51,11 @@ export type GqlPageNode = {
 	};
 };
 
-// Shared shape for featured image nodes returned by list/feed queries (no altText).
+// Shared shape for featured image nodes returned by list/feed queries.
 export type PostFeaturedImageListNode = {
 	sourceUrl: string;
 	srcSet: string;
+	altText?: string;
 	mediaDetails?: { width?: number; height?: number };
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,17 +50,20 @@ export type GqlPageNode = {
 	};
 };
 
+// Shared shape for featured image nodes returned by list/feed queries (no altText).
+export type PostFeaturedImageListNode = {
+	sourceUrl: string;
+	srcSet: string;
+	mediaDetails?: { width?: number; height?: number };
+};
+
 export type AllPostsNode = {
 	date: string;
 	slug: string;
 	title: string;
 	content: string;
 	featuredImage?: {
-		node?: {
-			sourceUrl: string;
-			srcSet: string;
-			mediaDetails?: { width?: number; height?: number };
-		};
+		node?: PostFeaturedImageListNode;
 	};
 };
 
@@ -84,47 +87,36 @@ export type GetPageByIdResponse = {
 	page: GqlPageNode | null;
 };
 
+// Seasonal forecast posts share the same query shape as AllPostsNode.
 export type SeasonalPostsResponse = {
 	posts: {
-		nodes: Array<{
-			date: string;
-			slug: string;
-			title: string;
-			content: string;
-			featuredImage?: {
-				node?: {
-					sourceUrl: string;
-					srcSet: string;
-					mediaDetails?: { width?: number; height?: number };
-				};
-			};
-		}>;
+		nodes: Array<AllPostsNode>;
+	};
+};
+
+export type LatestSeasonalPost = {
+	slug: string;
+	title: string;
+	date: string;
+	featuredImage?: {
+		node?: PostFeaturedImageListNode;
 	};
 };
 
 export type LatestSeasonalPostResponse = {
 	posts: {
-		nodes: Array<{
-			slug: string;
-			title: string;
-			date: string;
-			featuredImage?: {
-				node?: {
-					sourceUrl: string;
-					srcSet: string;
-					mediaDetails?: { width?: number; height?: number };
-				};
-			};
-		}>;
+		nodes: Array<LatestSeasonalPost>;
 	};
+};
+
+export type OnThisDayPost = {
+	title: string;
+	slug: string;
+	date: string;
 };
 
 export type OnThisDayResponse = {
 	posts: {
-		nodes: Array<{
-			title: string;
-			slug: string;
-			date: string;
-		}>;
+		nodes: Array<OnThisDayPost>;
 	};
 };

--- a/src/routes/monthly-summary/[year]/[month]/+page.svelte
+++ b/src/routes/monthly-summary/[year]/[month]/+page.svelte
@@ -4,7 +4,7 @@
 
 	const { data }: PageProps = $props();
 
-	const { summary } = data;
+	const summary = $derived(data.summary);
 
 	const postUrl = $derived(
 		`https://www.readingweather.co.uk/monthly-summary/${summary.year}/${String(summary.month).padStart(2, '0')}`


### PR DESCRIPTION
## Summary

TypeScript & typing improvements for 2026-07-27. Three focused changes:

**`src/lib/types.ts` — eliminate duplicate inline shapes**
- Extracted `PostFeaturedImageListNode` as a named exported type, replacing three identical inline `{ sourceUrl, srcSet, mediaDetails? }` object shapes spread across `AllPostsNode`, `SeasonalPostsResponse`, and `LatestSeasonalPostResponse`
- Extracted `LatestSeasonalPost` as a named exported type so the seasonal-post node shape is accessible without drilling into the response wrapper
- Extracted `OnThisDayPost` as a named exported type so the component can import it rather than redeclaring an identical local type
- Simplified `SeasonalPostsResponse` to reuse `AllPostsNode[]` — the all-seasonal-posts query returns the same fields and the component already passes these nodes directly to `PostList` which expects `AllPostsNode[]`

**`src/lib/components/OnThisDay.svelte`**
- Removed the locally-defined `OnThisDayPost` type and imported the canonical one from `$lib/types`; the two shapes were identical, so a future change to the API response type would previously have required updating both

**`src/routes/monthly-summary/[year]/[month]/+page.svelte`**
- Fixed a Svelte 5 `state_referenced_locally` warning: `const { summary } = data` was capturing the initial value of `data.summary` rather than tracking it reactively. Changed to `const summary = $derived(data.summary)` so the binding stays live if the prop updates (e.g. during client-side navigation between month pages)

**Result:** `yarn svelte-check` now reports **0 errors, 0 warnings** (previously 1 warning). `yarn lint` passes cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_018xR6AoK5TYRMXLgPotBQNZ)_