### PR TITLE
feat: add RSS feed at /feed.xml

### DIFF
--- a/src/lib/server/feed.ts
+++ b/src/lib/server/feed.ts
@@ -1,0 +1,88 @@
+import { fetchGraphQL } from '$lib/graphql/api';
+import { getCache, setCache } from './cache';
+
+const ALL_POSTS_FEED_QUERY = `
+  query AllPostsForFeed {
+    posts(first: 50) {
+      nodes {
+        slug
+        title
+        date
+        excerpt
+        featuredImage {
+          node {
+            sourceUrl(size: MEDIUM_LARGE)
+          }
+        }
+      }
+    }
+  }
+`;
+
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export type FeedNode = {
+	slug: string;
+	title: string;
+	date: string | null;
+	excerpt?: string | null;
+	featuredImage?: { node?: { sourceUrl?: string } };
+};
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;');
+}
+
+function stripHtml(value: string): string {
+	return value.replace(/<[^>]*>/g, '').trim();
+}
+
+function toRssItem(node: FeedNode, base: string): string {
+	const link = `${base}/${node.slug}`;
+	const pubDate = node.date ? new Date(node.date).toUTCString() : undefined;
+	const description = node.excerpt ? stripHtml(node.excerpt) : '';
+	const imageUrl = node.featuredImage?.node?.sourceUrl;
+
+	return `
+    <item>
+      <title>${escapeXml(node.title)}</title>
+      <link>${escapeXml(link)}</link>
+      <guid isPermaLink="true">${escapeXml(link)}</guid>
+      ${pubDate ? `<pubDate>${pubDate}</pubDate>` : ''}
+      <description>${escapeXml(description)}</description>
+      ${imageUrl ? `<enclosure url="${escapeXml(imageUrl)}" type="image/jpeg" />` : ''}
+    </item>`;
+}
+
+export async function fetchFeedPosts(): Promise<FeedNode[]> {
+	const cached = getCache<FeedNode[]>('feed-posts');
+	if (cached) return cached;
+
+	const data = await fetchGraphQL<{ posts: { nodes: FeedNode[] } }>(ALL_POSTS_FEED_QUERY);
+	const nodes = data.posts.nodes;
+	setCache('feed-posts', nodes, CACHE_TTL_MS);
+	return nodes;
+}
+
+export function generateFeedXml(nodes: FeedNode[], base: string): string {
+	const items = nodes.map((node) => toRssItem(node, base));
+	const lastBuildDate = new Date().toUTCString();
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Reading Weather</title>
+    <link>${base}</link>
+    <atom:link href="${base}/feed.xml" rel="self" type="application/rss+xml" />
+    <description>Weather forecasts for Reading and Berkshire</description>
+    <language>en-gb</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+${items.join('\n')}
+  </channel>
+</rss>`;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,6 +46,7 @@
 	<link rel="preload" href="/fonts/Caveat-VariableFont_wght.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
 	<link rel="preload" href="/fonts/FiraSans-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
 	<link rel="canonical" href={`https://www.readingweather.co.uk${$page.url.pathname}`} />
+	<link rel="alternate" type="application/rss+xml" title="Reading Weather" href="/feed.xml" />
 	<meta property="og:site_name" content="Reading Weather" />
 	<meta property="og:locale" content="en_GB" />
 	<meta name="twitter:card" content="summary_large_image" />
@@ -77,5 +78,6 @@
 
 		<p class="response" role="status" aria-live="polite">{responseMessage}</p>
 	</div>
+	<p><a href="/feed.xml">Subscribe via RSS</a></p>
 	<p>&copy; {new Date().getFullYear()} Weather Forecast For Reading & Berkshire</p>
 </footer>

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -1,0 +1,21 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { fetchFeedPosts, generateFeedXml } from '$lib/server/feed';
+
+export const GET: RequestHandler = async () => {
+	const base = 'https://www.readingweather.co.uk';
+
+	try {
+		const nodes = await fetchFeedPosts();
+		const xml = generateFeedXml(nodes, base);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/rss+xml; charset=utf-8',
+				'Cache-Control': 'max-age=0, s-maxage=1800'
+			}
+		});
+	} catch (err) {
+		console.error('Feed generation error', err);
+		return new Response('Internal Server Error', { status: 500 });
+	}
+};

--- a/src/routes/feed.xml/server.spec.ts
+++ b/src/routes/feed.xml/server.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './+server';
+
+vi.mock('$lib/graphql/api', () => ({
+	fetchGraphQL: vi.fn()
+}));
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn().mockReturnValue(null),
+	setCache: vi.fn()
+}));
+
+import { fetchGraphQL } from '$lib/graphql/api';
+
+function makeRequest() {
+	return {} as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('GET /feed.xml', () => {
+	it('returns valid RSS XML with the correct content-type header and includes post details', async () => {
+		vi.mocked(fetchGraphQL).mockResolvedValueOnce({
+			posts: {
+				nodes: [
+					{
+						slug: 'sunny-reading-june',
+						title: 'Sunny spells for June',
+						date: '2025-06-01T09:00:00',
+						excerpt: '<p>A warm and bright start to the month.</p>',
+						featuredImage: { node: { sourceUrl: 'https://blog.readingweather.co.uk/image.jpg' } }
+					}
+				]
+			}
+		});
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('application/rss+xml; charset=utf-8');
+		const body = await response.text();
+		expect(body).toContain('<?xml version="1.0"');
+		expect(body).toContain('<rss version="2.0"');
+		expect(body).toContain('Sunny spells for June');
+		expect(body).toContain('https://www.readingweather.co.uk/sunny-reading-june');
+		expect(body).toContain('A warm and bright start to the month.');
+		expect(body).toContain('<enclosure url="https://blog.readingweather.co.uk/image.jpg"');
+	});
+
+	it('returns a 500 response when fetchGraphQL throws', async () => {
+		vi.mocked(fetchGraphQL).mockRejectedValueOnce(new Error('GraphQL unavailable'));
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(500);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `/feed.xml` (RSS 2.0) built from the latest 50 posts via a new `AllPostsForFeed`-style GraphQL query, cached 30 minutes server-side
- Each item includes title, link, guid, pubDate, HTML-stripped excerpt as description, and an `<enclosure>` for the featured image
- Auto-discovery `<link rel="alternate" type="application/rss+xml">` added to the layout `<head>`
- "Subscribe via RSS" link added to the footer
- `Cache-Control: max-age=0, s-maxage=1800` keeps the feed from going stale for more than 30 minutes

Closes #434

## Test plan
- [x] `yarn vitest run` — all 189 tests pass, including new `src/routes/feed.xml/server.spec.ts` covering successful XML output and the 500-on-error path
- [x] `yarn svelte-check` — 0 errors
- [ ] Validate `/feed.xml` against the [W3C Feed Validation Service](https://validator.w3.org/feed/) once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)