### PR TITLE
perf: eliminate self-HTTP round-trips and serve gallery thumbnails at correct size

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,13 @@
-import type { DailyWeather } from '$lib/api/historicalWeather';
+import { type DailyWeather, fetchHistoricalWeather } from '$lib/api/historicalWeather';
 import { fetchGraphQL } from '$lib/graphql/api';
 import ALL_POSTS_QUERY from '$lib/graphql/queries/allPosts';
 import GET_LATEST_SEASONAL_POST_QUERY from '$lib/graphql/queries/getLatestSeasonalPost';
 import GET_POSTS_ON_THIS_DAY from '$lib/graphql/queries/getPostsOnThisDay';
+import { getCache, setCache } from '$lib/server/cache';
 import type { AllPostsResponse, LatestSeasonalPostResponse, OnThisDayResponse } from '$lib/types';
 import type { PageServerLoad } from './$types';
+
+const HISTORICAL_WEATHER_TTL_MS = 24 * 60 * 60 * 1000;
 
 function lastCompletedMonth(now: Date): { year: number; month: number } {
 	const year = now.getUTCFullYear();
@@ -23,15 +26,21 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		{ month: 'long', year: 'numeric', timeZone: 'UTC' }
 	);
 
+	const historicalWeatherCacheKey = `historical-weather-${month}-${day}`;
+
 	const [postsResult, latestSeasonalPost, onThisDay, historicalWeather] = await Promise.all([
 		fetchGraphQL<AllPostsResponse>(ALL_POSTS_QUERY, {}, fetch).catch(() => null),
 		fetchGraphQL<LatestSeasonalPostResponse>(GET_LATEST_SEASONAL_POST_QUERY, {}, fetch).catch(
 			() => null
 		),
 		fetchGraphQL<OnThisDayResponse>(GET_POSTS_ON_THIS_DAY, { month, day }, fetch).catch(() => null),
-		fetch(`/api/historical-weather?month=${month}&day=${day}`)
-			.then((r) => (r.ok ? (r.json() as Promise<DailyWeather[]>) : null))
-			.catch(() => null)
+		(async (): Promise<DailyWeather[] | null> => {
+			const cached = getCache<DailyWeather[]>(historicalWeatherCacheKey);
+			if (cached) return cached;
+			const data = await fetchHistoricalWeather(month, day).catch(() => null);
+			if (data) setCache(historicalWeatherCacheKey, data, HISTORICAL_WEATHER_TTL_MS);
+			return data;
+		})()
 	]);
 
 	const meta = {

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -114,7 +114,7 @@
 									aria-label="View full size: {post.name}"
 								>
 									<img
-										src={post.featuredImage.node.sourceUrl}
+										src={post.thumbnailUrl}
 										srcset={post.featuredImage.node.srcSet}
 										sizes="(min-width: 480px) 200px, 100vw"
 										alt={post.name}

--- a/src/routes/monthly-summary/[year]/[month]/+page.server.ts
+++ b/src/routes/monthly-summary/[year]/[month]/+page.server.ts
@@ -1,8 +1,12 @@
 import { error } from '@sveltejs/kit';
-import type { MonthlySummary } from '$lib/api/monthlySummary';
+import { fetchMonthlySummary, type MonthlySummary } from '$lib/api/monthlySummary';
+import { getCache, setCache } from '$lib/server/cache';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
+const SUMMARY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const SUMMARY_ERROR_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export const load: PageServerLoad = async ({ params, setHeaders }) => {
 	const year = Number(params.year);
 	const month = Number(params.month);
 
@@ -10,19 +14,29 @@ export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
 		throw error(404, 'Monthly summary not found');
 	}
 
-	const response = await fetch(`/api/monthly-summary?year=${year}&month=${month}`);
-	if (!response.ok) {
-		if (response.status === 502) {
-			throw error(503, 'This report is temporarily unavailable — please try again in a few minutes.');
-		}
-		throw error(404, 'Monthly summary not found');
+	const cacheKey = `monthly-summary-${year}-${month}`;
+	const cached = getCache<MonthlySummary>(cacheKey);
+	if (cached) {
+		setHeaders({ 'cache-control': 'public, max-age=31536000, immutable' });
+		return { summary: cached };
 	}
 
-	const summary = (await response.json()) as MonthlySummary;
+	const errorCacheKey = `${cacheKey}-error`;
+	if (getCache<true>(errorCacheKey)) {
+		throw error(503, 'This report is temporarily unavailable — please try again in a few minutes.');
+	}
 
-	// A page that loads successfully only ever describes a fully completed past
-	// month, so its content never changes again once published.
-	setHeaders({ 'cache-control': 'public, max-age=31536000, immutable' });
-
-	return { summary };
+	try {
+		const summary = await fetchMonthlySummary(year, month);
+		setCache(cacheKey, summary, SUMMARY_CACHE_TTL_MS);
+		setHeaders({ 'cache-control': 'public, max-age=31536000, immutable' });
+		return { summary };
+	} catch (fetchErr) {
+		if (fetchErr instanceof Error && fetchErr.message.includes('fully completed months')) {
+			throw error(404, 'Monthly summary not found');
+		}
+		setCache(errorCacheKey, true as const, SUMMARY_ERROR_CACHE_TTL_MS);
+		console.error('fetchMonthlySummary failed:', fetchErr);
+		throw error(503, 'This report is temporarily unavailable — please try again in a few minutes.');
+	}
 };

--- a/src/routes/monthly-summary/[year]/[month]/page.spec.ts
+++ b/src/routes/monthly-summary/[year]/[month]/page.spec.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { load } from './+page.server';
+
+vi.mock('$lib/api/monthlySummary', () => ({
+	fetchMonthlySummary: vi.fn()
+}));
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn(() => null),
+	setCache: vi.fn()
+}));
+
+import { fetchMonthlySummary } from '$lib/api/monthlySummary';
 
 const mockSummary = {
 	year: 2026,
@@ -24,49 +35,55 @@ const mockSummary = {
 		hottestDay: { date: '2026-06-20', year: 2026, value: 32.1 },
 		coldestDay: { date: '1962-06-02', year: 1962, value: 1.2 },
 		wettestDay: { date: '1971-06-14', year: 1971, value: 40.5 }
-	}
+	},
+	condition: { category: 'sunny' as const, label: 'sunny' },
+	streak: { type: 'dry' as const, emoji: '☀️', length: 7, label: '7 consecutive dry days' }
 };
 
-function makeEvent(params: Record<string, string>, fetchImpl: typeof fetch) {
+function makeEvent(params: Record<string, string>) {
 	return {
 		params,
-		fetch: fetchImpl,
 		setHeaders: vi.fn()
 	} as unknown as Parameters<typeof load>[0];
 }
 
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
 describe('monthly-summary/[year]/[month] load', () => {
 	it('loads the summary from the API and sets an immutable cache header', async () => {
-		const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mockSummary });
-		const event = makeEvent({ year: '2026', month: '06' }, mockFetch);
+		vi.mocked(fetchMonthlySummary).mockResolvedValue(mockSummary);
+		const event = makeEvent({ year: '2026', month: '06' });
 
 		const result = await load(event);
 
 		expect(result).toEqual({ summary: mockSummary });
-		expect(mockFetch).toHaveBeenCalledWith('/api/monthly-summary?year=2026&month=6');
+		expect(fetchMonthlySummary).toHaveBeenCalledWith(2026, 6);
 		expect(event.setHeaders).toHaveBeenCalledWith({
 			'cache-control': 'public, max-age=31536000, immutable'
 		});
 	});
 
 	it('throws a 404 when the month param is out of range', async () => {
-		const mockFetch = vi.fn();
-		const event = makeEvent({ year: '2026', month: '13' }, mockFetch);
+		const event = makeEvent({ year: '2026', month: '13' });
 
 		await expect(load(event)).rejects.toMatchObject({ status: 404 });
-		expect(mockFetch).not.toHaveBeenCalled();
+		expect(fetchMonthlySummary).not.toHaveBeenCalled();
 	});
 
-	it('throws a 404 when the API responds with an error', async () => {
-		const mockFetch = vi.fn().mockResolvedValue({ ok: false });
-		const event = makeEvent({ year: '2026', month: '07' }, mockFetch);
+	it('throws a 404 when the API reports the month is not yet fully completed', async () => {
+		vi.mocked(fetchMonthlySummary).mockRejectedValue(
+			new Error('Monthly summaries are only available for fully completed months')
+		);
+		const event = makeEvent({ year: '2026', month: '07' });
 
 		await expect(load(event)).rejects.toMatchObject({ status: 404 });
 	});
 
 	it('throws a 503 when the API reports the upstream is temporarily unavailable', async () => {
-		const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
-		const event = makeEvent({ year: '2026', month: '07' }, mockFetch);
+		vi.mocked(fetchMonthlySummary).mockRejectedValue(new Error('Open-Meteo error: 502'));
+		const event = makeEvent({ year: '2026', month: '07' });
 
 		await expect(load(event)).rejects.toMatchObject({ status: 503 });
 	});

--- a/src/routes/page.spec.ts
+++ b/src/routes/page.spec.ts
@@ -7,6 +7,16 @@ vi.mock('$lib/graphql/api', () => ({
 	fetchGraphQL: vi.fn()
 }));
 
+vi.mock('$lib/api/historicalWeather', () => ({
+	fetchHistoricalWeather: vi.fn()
+}));
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn(() => null),
+	setCache: vi.fn()
+}));
+
+import { fetchHistoricalWeather } from '$lib/api/historicalWeather';
 import { fetchGraphQL } from '$lib/graphql/api';
 
 const mockPosts = {
@@ -40,11 +50,11 @@ const mockOnThisDay = {
 	}
 };
 
-const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+const mockFetch = vi.fn();
 
 beforeEach(() => {
 	vi.clearAllMocks();
-	mockFetch.mockResolvedValue({ ok: false });
+	vi.mocked(fetchHistoricalWeather).mockResolvedValue([]);
 });
 
 describe('home page load', () => {
@@ -128,7 +138,7 @@ describe('home page load', () => {
 			.mockResolvedValueOnce(mockSeasonalResponse)
 			.mockResolvedValueOnce(mockOnThisDay);
 		const weatherData = [{ year: 2024, tempMax: 22, tempMin: 11, precipitation: 0, windSpeedMax: 10, conditions: { morning: 'clear sky', afternoon: 'mainly clear', evening: 'clear sky' } }];
-		mockFetch.mockResolvedValueOnce({ ok: true, json: async () => weatherData });
+		vi.mocked(fetchHistoricalWeather).mockResolvedValueOnce(weatherData);
 
 		const result = await load({ setHeaders: vi.fn(), fetch: mockFetch } as unknown as Parameters<typeof load>[0]) as LoadResult;
 


### PR DESCRIPTION
## Summary

Three targeted performance improvements identified during a codebase audit.

### 1. Eliminate self-HTTP call in root page load (`+page.server.ts`)

The homepage server load was calling `fetch('/api/historical-weather?...')` — a full HTTP round-trip from the SvelteKit server back to itself — to retrieve historical weather data for "on this day" comparisons. The underlying function (`fetchHistoricalWeather`) is available server-side and was already imported by the API route handler.

**Fix:** Call `fetchHistoricalWeather()` directly from the load function, and replicate the same in-process cache (24-hour TTL, keyed identically to the API route's cache) so cold-start and warm-hit behaviour is identical to before. The API route itself is unchanged and still serves external consumers.

### 2. Eliminate self-HTTP call in monthly summary page load

`/src/routes/monthly-summary/[year]/[month]/+page.server.ts` was calling `fetch('/api/monthly-summary?...')`, another server-to-self HTTP round-trip. The `fetchMonthlySummary()` function is importable directly.

**Fix:** Call `fetchMonthlySummary()` directly, replicating the full cache behaviour from the API route:
- 24-hour success cache
- 5-minute error cache to avoid hammering a temporarily-unavailable Open-Meteo upstream
- Same error classifications as before: 404 for requests to not-yet-complete months, 503 for upstream failures

### 3. Gallery thumbnails use pre-computed thumbnail URL

`/src/routes/gallery/+page.server.ts` already resolves a `thumbnailUrl` for each gallery post (preferring `medium_large` → `medium` → `thumbnail` from WordPress's media sizes), and stores it on the `GalleryPostWithImage` type. However, the gallery template was passing `post.featuredImage.node.sourceUrl` — the full-resolution original — as the `src` attribute on thumbnail images. The computed `thumbnailUrl` was threaded through the data layer but never referenced.

**Fix:** Use `post.thumbnailUrl` as `src` on gallery thumbnail `<img>` elements. The full-resolution URL is still used for the lightbox (opened on click), so image quality when viewing full-size is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpaTt1Nj1ahP3r4TahoHSW)_