### PR TITLE
chore(a11y/seo): accessibility and SEO improvements

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-GB">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png" />

--- a/src/lib/components/AddComment.svelte
+++ b/src/lib/components/AddComment.svelte
@@ -61,15 +61,15 @@
 	{#if !successMessage}
 		<div>
 			<label for="name-{fieldPrefix}">Name:</label>
-			<input type="text" bind:value={name} id="name-{fieldPrefix}" name="name" autocomplete="name" required aria-required="true" />
+			<input type="text" bind:value={name} id="name-{fieldPrefix}" name="name" autocomplete="name" required />
 		</div>
 		<div>
 			<label for="email-{fieldPrefix}">Email:</label>
-			<input type="email" bind:value={email} id="email-{fieldPrefix}" name="email" autocomplete="email" required aria-required="true" />
+			<input type="email" bind:value={email} id="email-{fieldPrefix}" name="email" autocomplete="email" required />
 		</div>
 		<div>
 			<label for="comment-{fieldPrefix}">Comment:</label>
-			<textarea bind:value={commentContent} id="comment-{fieldPrefix}" name="comment" autocomplete="off" required aria-required="true"></textarea>
+			<textarea bind:value={commentContent} id="comment-{fieldPrefix}" name="comment" autocomplete="off" required></textarea>
 		</div>
 		<button type="submit" disabled={submitting}>
 			{submitting ? 'Submitting...' : 'Post Comment'}

--- a/src/lib/components/Comments.svelte
+++ b/src/lib/components/Comments.svelte
@@ -13,8 +13,8 @@
 	const replyForms = writable<Record<string, boolean>>({});
 </script>
 
-<section id="comments" class="comments-block">
-	<h2>Any comments?</h2>
+<section id="comments" class="comments-block" aria-labelledby="comments-heading">
+	<h2 id="comments-heading">Any comments?</h2>
 	{#if threadedComments.length > 0}
 		<ul class="comments-list">
 			{#each threadedComments as comment}

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -25,6 +25,8 @@
 	});
 </script>
 
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape' && isOpen) isOpen = false; }} />
+
 <nav class="navbar" aria-label="Main navigation">
 	<a href="/" class="home-button">Home</a>
 	<button

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -26,7 +26,7 @@
 							src={post.featuredImage.node.sourceUrl}
 							srcset={post.featuredImage.node.srcSet}
 							sizes="(min-width: 768px) 700px, 100vw"
-							alt=""
+							alt={post.featuredImage?.node?.altText || ''}
 							width={post.featuredImage.node.mediaDetails?.width ?? undefined}
 							height={post.featuredImage.node.mediaDetails?.height ?? undefined}
 							loading={i === 0 ? 'eager' : 'lazy'}

--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -42,7 +42,10 @@
 <div class="share">
 	<p class="share-label">Found this forecast useful?</p>
 	<div class="share-buttons">
-		<button onclick={copyLink} aria-label="Copy link to this forecast">
+		<button
+			onclick={copyLink}
+			aria-label={copied ? 'Link copied to clipboard' : 'Copy link to this forecast'}
+		>
 			{copied ? 'Copied!' : 'Copy link'}
 		</button>
 		<button onclick={shareOnBluesky} aria-label="Share this forecast on Bluesky (opens in new tab)">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,8 +41,8 @@
 </script>
 
 <svelte:head>
-	<link rel="preconnect" href="https://blog.readingweather.co.uk" />
-	<link rel="preconnect" href="https://www.googletagmanager.com" />
+	<link rel="preconnect" href="https://blog.readingweather.co.uk" crossorigin="anonymous" />
+	<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin="anonymous" />
 	<link rel="preload" href="/fonts/Caveat-VariableFont_wght.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
 	<link rel="preload" href="/fonts/FiraSans-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
 	<link rel="canonical" href={`https://www.readingweather.co.uk${$page.url.pathname}`} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -67,11 +67,11 @@
 <form id="subscribe-form" aria-labelledby="subscribe-heading" onsubmit={handleSubmit}>
 			<label for="subscribe-name">
 				Name:
-				<input id="subscribe-name" autocomplete="name" type="text" bind:value={name} required aria-required="true" />
+				<input id="subscribe-name" autocomplete="name" type="text" bind:value={name} required />
 			</label>
 			<label for="subscribe-email">
 				Email:
-				<input id="subscribe-email" autocomplete="email" type="email" bind:value={email} required aria-required="true" />
+				<input id="subscribe-email" autocomplete="email" type="email" bind:value={email} required />
 			</label>
 			<button type="submit">Subscribe</button>
 		</form>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -55,7 +55,7 @@
 {#if data.lastMonth}
 	<section class="monthly-summary-teaser">
 		<a href="/monthly-summary/{data.lastMonth.year}/{String(data.lastMonth.month).padStart(2, '0')}">
-			📅 {data.lastMonth.label} report card
+			<span aria-hidden="true">📅</span> {data.lastMonth.label} report card
 		</a>
 	</section>
 {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,11 +53,11 @@
 <WeeklyDigest />
 
 {#if data.lastMonth}
-	<section class="monthly-summary-teaser">
+	<div class="monthly-summary-teaser">
 		<a href="/monthly-summary/{data.lastMonth.year}/{String(data.lastMonth.month).padStart(2, '0')}">
 			<span aria-hidden="true">📅</span> {data.lastMonth.label} report card
 		</a>
-	</section>
+	</div>
 {/if}
 
 <WeekInHistory />

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -56,11 +56,12 @@
 		headline: postTitle,
 		description: postDescription,
 		url: postUrl,
+		inLanguage: 'en-GB',
 		mainEntityOfPage: { '@type': 'WebPage', '@id': postUrl },
 		...(data.post.date ? { datePublished: data.post.date } : {}),
-		...(data.post.featuredImage?.node?.sourceUrl
-			? { image: data.post.featuredImage.node.sourceUrl }
-			: {}),
+		image:
+			data.post.featuredImage?.node?.sourceUrl ??
+			'https://www.readingweather.co.uk/images/weather.png',
 		author: {
 			'@type': 'Organization',
 			name: 'Reading Weather',

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -6,7 +6,7 @@
 
 	const jsonLd = $derived({
 		'@context': 'https://schema.org',
-		'@type': 'WebPage',
+		'@type': 'AboutPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -73,7 +73,7 @@
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:image:alt" content="Photo gallery of weather conditions in Reading and Berkshire" />
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content={`https://www.readingweather.co.uk/gallery${data.selectedYear ? `?year=${data.selectedYear}` : ''}`} />
+	<meta property="og:url" content="https://www.readingweather.co.uk/gallery" />
 	<meta name="twitter:title" content="Photo Gallery – Reading Weather" />
 	<meta name="twitter:description" content="A photo gallery of weather conditions in Reading and Berkshire, organised by month and year." />
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />

--- a/src/routes/monthly-summary/+page.svelte
+++ b/src/routes/monthly-summary/+page.svelte
@@ -17,14 +17,39 @@
 		'November',
 		'December'
 	];
+
+	const monthlySummaryDescription =
+		"Browse monthly weather report cards for Reading, comparing each month's temperature, rainfall and sunshine against the historical average.";
+
+	const jsonLd = {
+		'@context': 'https://schema.org',
+		'@type': 'CollectionPage',
+		name: 'Monthly Weather Report Cards',
+		description: monthlySummaryDescription,
+		url: 'https://www.readingweather.co.uk/monthly-summary'
+	};
 </script>
 
 <svelte:head>
 	<title>Monthly Weather Report Cards | Reading Weather</title>
+	<meta name="description" content={monthlySummaryDescription} />
+	<meta property="og:title" content="Monthly Weather Report Cards | Reading Weather" />
+	<meta property="og:description" content={monthlySummaryDescription} />
+	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta
-		name="description"
-		content="Browse monthly weather report cards for Reading, comparing each month's temperature, rainfall and sunshine against the historical average."
+		property="og:image:alt"
+		content="Reading Weather – weather forecasts for Reading and Berkshire"
 	/>
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="https://www.readingweather.co.uk/monthly-summary" />
+	<meta name="twitter:title" content="Monthly Weather Report Cards | Reading Weather" />
+	<meta name="twitter:description" content={monthlySummaryDescription} />
+	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta
+		name="twitter:image:alt"
+		content="Reading Weather – weather forecasts for Reading and Berkshire"
+	/>
+	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
 <h1>Monthly Weather Report Cards</h1>

--- a/src/routes/monthly-summary/+page.svelte
+++ b/src/routes/monthly-summary/+page.svelte
@@ -3,6 +3,18 @@
 
 	const { data }: PageProps = $props();
 
+	const monthlySummaryDescription =
+		"Browse monthly weather report cards for Reading, comparing each month's temperature, rainfall and sunshine against the historical average.";
+
+	const jsonLd = {
+		'@context': 'https://schema.org',
+		'@type': 'CollectionPage',
+		name: 'Monthly Weather Report Cards',
+		description: monthlySummaryDescription,
+		url: 'https://www.readingweather.co.uk/monthly-summary',
+		isPartOf: { '@type': 'WebSite', name: 'Reading Weather', url: 'https://www.readingweather.co.uk' }
+	};
+
 	const MONTH_NAMES = [
 		'January',
 		'February',
@@ -17,17 +29,6 @@
 		'November',
 		'December'
 	];
-
-	const monthlySummaryDescription =
-		"Browse monthly weather report cards for Reading, comparing each month's temperature, rainfall and sunshine against the historical average.";
-
-	const jsonLd = {
-		'@context': 'https://schema.org',
-		'@type': 'CollectionPage',
-		name: 'Monthly Weather Report Cards',
-		description: monthlySummaryDescription,
-		url: 'https://www.readingweather.co.uk/monthly-summary'
-	};
 </script>
 
 <svelte:head>

--- a/src/routes/monthly-summary/[year]/[month]/+page.svelte
+++ b/src/routes/monthly-summary/[year]/[month]/+page.svelte
@@ -17,7 +17,12 @@
 		name: `${summary.label} Weather Report Card`,
 		description: summary.headline,
 		url: postUrl,
-		temporalCoverage: `${summary.year}-${String(summary.month).padStart(2, '0')}`,
+		temporalCoverage: (() => {
+			const year = summary.year;
+			const month = String(summary.month).padStart(2, '0');
+			const lastDay = new Date(year, summary.month, 0).getDate();
+			return `${year}-${month}-01/${year}-${month}-${String(lastDay).padStart(2, '0')}`;
+		})(),
 		spatialCoverage: {
 			'@type': 'Place',
 			name: 'Reading, UK'

--- a/src/routes/monthly-summary/[year]/[month]/+page.svelte
+++ b/src/routes/monthly-summary/[year]/[month]/+page.svelte
@@ -44,10 +44,20 @@
 	<meta name="description" content={summary.headline} />
 	<meta property="og:title" content={postTitle} />
 	<meta property="og:description" content={summary.headline} />
+	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta
+		property="og:image:alt"
+		content="Reading Weather – weather forecasts for Reading and Berkshire"
+	/>
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content={postUrl} />
 	<meta name="twitter:title" content={postTitle} />
 	<meta name="twitter:description" content={summary.headline} />
+	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
+	<meta
+		name="twitter:image:alt"
+		content="Reading Weather – weather forecasts for Reading and Berkshire"
+	/>
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
@@ -100,7 +110,7 @@
 				<p>Most common condition: <strong>{summary.condition.label}</strong></p>
 			{/if}
 			{#if summary.streak}
-				<p>Longest streak: <strong>{summary.streak.label}</strong> {summary.streak.emoji}</p>
+				<p>Longest streak: <strong>{summary.streak.label}</strong> <span aria-hidden="true">{summary.streak.emoji}</span></p>
 			{/if}
 		</div>
 	{/if}

--- a/src/routes/useful-links/+page.svelte
+++ b/src/routes/useful-links/+page.svelte
@@ -10,7 +10,7 @@
 
 	const jsonLd = $derived({
 		'@context': 'https://schema.org',
-		'@type': 'WebPage',
+		'@type': 'CollectionPage',
 		name: data.page.title,
 		description: data.page.seo.description,
 		url: `https://www.readingweather.co.uk/${data.page.slug}`


### PR DESCRIPTION
## Summary

Automated accessibility and SEO pass (Sunday 2026-08-09, category: Accessibility & SEO).

### Metadata / SEO
- **`monthly-summary/+page.svelte`**: added full OG tags, Twitter card tags, and a `CollectionPage` JSON-LD block — previously the page had none of these, so links shared from this URL showed no preview image or rich metadata
- **`monthly-summary/[year]/[month]/+page.svelte`**: added missing `og:image`, `og:image:alt`, `twitter:image`, `twitter:image:alt` tags; fixed `temporalCoverage` in JSON-LD to use a proper ISO 8601 date range (`YYYY-MM-DD/YYYY-MM-DD`) instead of a truncated month string; removed a duplicate `og:image`/`og:image:alt` pair introduced by a rebase conflict
- **`[slug]/+page.svelte`**: added `inLanguage: "en-GB"` to `BlogPosting` JSON-LD; ensured `image` field always has a fallback URL (Google Search requires an image for article rich results)
- **`about/+page.svelte`**: changed JSON-LD `@type` from `WebPage` to `AboutPage` (the correct Schema.org subtype)
- **`useful-links/+page.svelte`**: changed JSON-LD `@type` from `WebPage` to `CollectionPage`
- **`gallery/+page.svelte`**: fixed `og:url` — it previously included `?year=…` query parameters, conflicting with the layout's canonical URL which strips query strings
- **`app.html`**: changed `lang="en"` to `lang="en-GB"` — the site uses British English throughout

### ARIA / Accessibility
- **`ShareButton.svelte`**: made the copy-link button's `aria-label` dynamic — it now reads "Link copied to clipboard" when the button is in the copied state, giving screen reader users confirmation that the copy succeeded
- **`Comments.svelte`**: added `aria-labelledby` to the `<section>` pointing to its `<h2>`, giving AT users a named landmark to navigate to
- **`+page.svelte` (home)**: wrapped the `📅` emoji in `<span aria-hidden="true">` so screen readers skip it; replaced the unnamed `<section>` wrapping the monthly teaser link with a `<div>` (a `<section>` without an accessible name is treated as a generic container)
- **`monthly-summary/[year]/[month]/+page.svelte`**: wrapped `summary.streak.emoji` in `<span aria-hidden="true">` — unlike the record list items below it, this emoji was being read aloud verbatim by screen readers
- **`AddComment.svelte`**: removed redundant `aria-required="true"` attributes — the HTML `required` attribute already exposes this to AT automatically
- **`+layout.svelte`**: removed redundant `aria-required="true"` from the subscribe form inputs for the same reason

### Image alt text
- **`PostList.svelte`**: used `post.featuredImage?.node?.altText` (the value stored in WordPress) instead of a hardcoded empty `alt=""` — weather images often carry meaningful content not captured by the post title alone; falls back to `""` when `altText` is genuinely absent