### PR TITLE
chore(types): fix LatestSeasonalPost type and remove as-cast in fetchArchive

### DIFF
--- a/src/lib/api/monthlySummary.ts
+++ b/src/lib/api/monthlySummary.ts
@@ -228,16 +228,18 @@ function lastCompleteYearForMonth(month: number, now: Date): number {
 const MAX_ATTEMPTS = 3;
 
 async function fetchArchive(url: string): Promise<Response> {
-	let response: Response | undefined;
 	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-		response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+		const response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
 		if (response.status !== 429 || attempt === MAX_ATTEMPTS) return response;
 
 		const retryAfterSeconds = Number(response.headers.get('retry-after'));
 		const delayMs = retryAfterSeconds > 0 ? retryAfterSeconds * 1000 : attempt * 1000;
 		await new Promise((resolve) => setTimeout(resolve, delayMs));
 	}
-	return response as Response;
+	// Unreachable: the loop always returns on the final attempt. TypeScript cannot
+	// prove this because MAX_ATTEMPTS is a runtime constant, not a literal in the
+	// loop bounds, so an explicit throw satisfies the control-flow analysis.
+	throw new Error('Unexpected: fetchArchive retry loop exhausted without returning');
 }
 
 async function fetchMonthlyBaseline(month: number, upToYear: number): Promise<MonthlyBaseline> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,20 +102,6 @@ export type LatestSeasonalPost = {
 	date: string;
 	featuredImage?: {
 		node?: PostFeaturedImageListNode;
-		nodes: Array<{
-			date: string;
-			slug: string;
-			title: string;
-			content: string;
-			featuredImage?: {
-				node?: {
-					sourceUrl: string;
-					srcSet: string;
-					altText?: string;
-					mediaDetails?: { width?: number; height?: number };
-				};
-			};
-		}>;
 	};
 };
 


### PR DESCRIPTION
## Summary

Two TypeScript correctness fixes identified during a routine Monday typing review:

- **`LatestSeasonalPost` type corrected** (`src/lib/types.ts`): The type had a spurious `featuredImage.nodes` array containing `AllPostsNode`-shaped fields. The `GetLatestSeasonalPost` GraphQL query only requests `featuredImage.node` (singular); the nested array had no corresponding data in the real API response and was dead type code that misled any developer reading the type definition.

- **`as Response` cast removed** (`src/lib/api/monthlySummary.ts`): The `fetchArchive` retry loop declared `let response: Response | undefined` then cast it back with `return response as Response` at the end. Refactored to declare `const response` inside each loop iteration and return directly on success, with an explicit `throw` at the end to satisfy TypeScript's control-flow analysis. The function behaviour is identical; the type assertion is gone.

## Test plan

- [x] `svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings (439 files)
- [x] `yarn lint` — no errors (biome schema version notice is pre-existing, unrelated to these changes)
- [x] `yarn test:unit --run` — 189/189 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSw63p6Uf8BEUD3SSfCvid)_