### PR TITLE
chore(typescript): improve typing consistency across API routes and lib

### DIFF
--- a/src/lib/api/monthlySummary.ts
+++ b/src/lib/api/monthlySummary.ts
@@ -60,15 +60,17 @@ function categoriseCode(code: number): ConditionCategory {
 
 export type MonthStreakType = 'dry' | 'wet' | 'warm' | 'cold';
 
-// Mirrors the thresholds in weatherStreak.ts's dry/wet/warm/cold definitions,
-// kept independent here since this streak is measured within a fixed calendar
-// month rather than as an ongoing run ending today.
-const MONTH_STREAK_DEFINITIONS: {
+type MonthStreakDefinition = {
 	type: MonthStreakType;
 	emoji: string;
 	label: (n: number) => string;
 	test: (tempMax: number, precipitation: number) => boolean;
-}[] = [
+};
+
+// Mirrors the thresholds in weatherStreak.ts's dry/wet/warm/cold definitions,
+// kept independent here since this streak is measured within a fixed calendar
+// month rather than as an ongoing run ending today.
+const MONTH_STREAK_DEFINITIONS: MonthStreakDefinition[] = [
 	{
 		type: 'dry',
 		emoji: '☀️',

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -1,1 +1,1 @@
-export const ALLOWED_ORIGINS = ['https://www.readingweather.co.uk', 'https://readingweather.co.uk'];
+export const ALLOWED_ORIGINS: readonly string[] = ['https://www.readingweather.co.uk', 'https://readingweather.co.uk'];

--- a/src/routes/api/comment/+server.ts
+++ b/src/routes/api/comment/+server.ts
@@ -1,7 +1,7 @@
-import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { addComment } from '$lib/graphql/api';
 import { ALLOWED_ORIGINS } from '$lib/server/config';
+import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
 	// CSRF: reject requests whose Origin doesn't match the app's own origin.

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -1,6 +1,6 @@
-import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { ALLOWED_ORIGINS } from '$lib/server/config';
+import type { RequestHandler } from './$types';
 
 const SUBSCRIBE_URL = 'https://blog.readingweather.co.uk/wp-json/custom/v1/subscribe';
 

--- a/src/routes/archives/+page.server.ts
+++ b/src/routes/archives/+page.server.ts
@@ -2,8 +2,8 @@ import { fetchGraphQL } from '$lib/graphql/api';
 import GET_POSTS_BY_DATE from '$lib/graphql/queries/getPostsByDate';
 import type { PageServerLoad } from './$types';
 
-type ArchiveEntry = { year: number; month: number };
-type ArchivePost = { title: string; slug: string; date: string };
+export type ArchiveEntry = { year: number; month: number };
+export type ArchivePost = { title: string; slug: string; date: string };
 
 const generateArchives = (): ArchiveEntry[] => {
 	const startYear = 2020;

--- a/src/routes/archives/page.spec.ts
+++ b/src/routes/archives/page.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ArchiveEntry, ArchivePost } from './+page.server';
 import { load } from './+page.server';
 
 vi.mock('$lib/graphql/api', () => ({
@@ -7,8 +8,6 @@ vi.mock('$lib/graphql/api', () => ({
 
 import { fetchGraphQL } from '$lib/graphql/api';
 
-type ArchiveEntry = { year: number; month: number };
-type ArchivePost = { title: string; slug: string; date: string };
 type ArchiveLoadResult = {
 	archives: ArchiveEntry[];
 	selectedYear: number;

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -1,5 +1,5 @@
-import type { RequestHandler } from '@sveltejs/kit';
 import { fetchFeedPosts, generateFeedXml } from '$lib/server/feed';
+import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async () => {
 	const base = 'https://www.readingweather.co.uk';

--- a/src/routes/sitemap-2.xml/+server.ts
+++ b/src/routes/sitemap-2.xml/+server.ts
@@ -1,5 +1,5 @@
-import type { RequestHandler } from '@sveltejs/kit';
 import { fetchSitemapPosts, generateSitemapXml, type StaticRoute } from '$lib/server/sitemap';
+import type { RequestHandler } from './$types';
 
 const staticRoutes: StaticRoute[] = [
 	{ path: '/', changefreq: 'daily', priority: '1.0' },

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,5 +1,5 @@
-import type { RequestHandler } from '@sveltejs/kit';
 import { fetchSitemapPosts, generateSitemapXml, type StaticRoute } from '$lib/server/sitemap';
+import type { RequestHandler } from './$types';
 
 const staticRoutes: StaticRoute[] = [
 	{ path: '/', changefreq: 'daily', priority: '1.0' },


### PR DESCRIPTION
## Summary

- **Route-scoped `RequestHandler` imports**: 5 server files were importing `RequestHandler` from `'@sveltejs/kit'` (the generic form) instead of `'./$types'` (the route-scoped form). The route-scoped version carries the correct `Params` type for each specific route and is consistent with the other five API route handlers in the codebase (`historical-weather`, `monthly-summary`, `weather-streak`, `week-in-history`, `weekly-digest` were already correct). Files fixed: `api/comment`, `api/subscribe`, `feed.xml`, `sitemap.xml`, `sitemap-2.xml`.
- **`ALLOWED_ORIGINS` explicit type**: Added `readonly string[]` annotation to `ALLOWED_ORIGINS` in `config.ts`, making the intent clear at every call site and preventing accidental mutation.
- **Named `MonthStreakDefinition` type**: Extracted the verbose inline object type on `MONTH_STREAK_DEFINITIONS` in `monthlySummary.ts` into a named `type MonthStreakDefinition`, matching the `StreakDefinition` pattern already used in `weatherStreak.ts`.
- **Deduplicate `ArchiveEntry`/`ArchivePost` types**: Exported these types from `archives/+page.server.ts` so `archives/page.spec.ts` can import the canonical definitions rather than maintaining its own copies.

## Test plan

- [x] `svelte-check` — 0 errors, 0 warnings (444 files checked)
- [x] `yarn lint` — passes cleanly (no errors; pre-existing Biome schema version info notice only)
- [x] `yarn test:unit` — 189/189 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGUP7SqsxLz2s283nGbyG1)_