### PR TITLE
perf: eliminate self-HTTP fetch in records load; move accented to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@types/node": "^24.10.0",
+		"accented": "^1.2.0",
 		"knip": "^6.0.0",
 		"prettier": "^3.5.3",
 		"prettier-plugin-svelte": "^4.0.0",
@@ -36,7 +37,6 @@
 		"vitest": "^4.0.0"
 	},
 	"dependencies": {
-		"accented": "^1.2.0",
 		"dompurify": "^3.2.5"
 	},
 	"resolutions": {

--- a/src/routes/records/+page.server.ts
+++ b/src/routes/records/+page.server.ts
@@ -1,18 +1,38 @@
 import { error } from '@sveltejs/kit';
-import type { RecordsTrackerResult } from '$lib/api/recordsTracker';
+import { fetchRecordsTracker, type RecordsTrackerResult } from '$lib/api/recordsTracker';
+import { getCache, setCache } from '$lib/server/cache';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
-	const response = await fetch('/api/records');
-	if (!response.ok) {
+const TTL_MS = 12 * 60 * 60 * 1000;
+const ERROR_TTL_MS = 5 * 60 * 1000;
+
+// Shared cache key format with /api/records so the first caller (page or API)
+// warms the cache for both.
+function todayCacheKey() {
+	return `records-tracker-${new Date().toISOString().slice(0, 10)}`;
+}
+
+export const load: PageServerLoad = async ({ setHeaders }) => {
+	const cacheKey = todayCacheKey();
+	const cached = getCache<RecordsTrackerResult>(cacheKey);
+	if (cached) {
+		setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=43200' });
+		return { records: cached };
+	}
+
+	if (getCache<true>(`${cacheKey}-error`)) {
 		throw error(503, 'Weather records are temporarily unavailable — please try again in a few minutes.');
 	}
 
-	const records = (await response.json()) as RecordsTrackerResult;
-
-	// New records can be set any day, so this stays fresh in step with the
-	// 12-hour TTL already applied to the underlying /api/records response.
-	setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=43200' });
-
-	return { records };
+	try {
+		const data = await fetchRecordsTracker();
+		setCache(cacheKey, data, TTL_MS);
+		// New records can be set any day, so this stays fresh in step with the 12-hour TTL.
+		setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=43200' });
+		return { records: data };
+	} catch (err) {
+		setCache(`${cacheKey}-error`, true, ERROR_TTL_MS);
+		console.error('fetchRecordsTracker failed:', err);
+		throw error(503, 'Weather records are temporarily unavailable — please try again in a few minutes.');
+	}
 };

--- a/src/routes/records/page.spec.ts
+++ b/src/routes/records/page.spec.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RecordsTrackerResult } from '$lib/api/recordsTracker';
-import { load } from './+page.server';
+
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	getCache: vi.fn((key: string) => cacheStore.get(key) ?? null),
+	setCache: vi.fn((key: string, data: unknown) => {
+		cacheStore.set(key, data);
+	})
+}));
 
 const mockRecords: RecordsTrackerResult = {
 	year: 2026,
@@ -12,30 +20,40 @@ const mockRecords: RecordsTrackerResult = {
 	allTimeRecords: []
 };
 
-function makeEvent(fetchImpl: typeof fetch) {
+vi.mock('$lib/api/recordsTracker', () => ({
+	fetchRecordsTracker: vi.fn()
+}));
+
+import { fetchRecordsTracker } from '$lib/api/recordsTracker';
+import { load } from './+page.server';
+
+function makeEvent() {
 	return {
-		fetch: fetchImpl,
 		setHeaders: vi.fn()
 	} as unknown as Parameters<typeof load>[0];
 }
 
+beforeEach(() => {
+	cacheStore.clear();
+	vi.clearAllMocks();
+});
+
 describe('records load', () => {
 	it('loads the records from the API and sets a cache header', async () => {
-		const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mockRecords });
-		const event = makeEvent(mockFetch);
+		vi.mocked(fetchRecordsTracker).mockResolvedValue(mockRecords);
+		const event = makeEvent();
 
 		const result = await load(event);
 
 		expect(result).toEqual({ records: mockRecords });
-		expect(mockFetch).toHaveBeenCalledWith('/api/records');
 		expect(event.setHeaders).toHaveBeenCalledWith({
 			'cache-control': 'public, max-age=0, s-maxage=43200'
 		});
 	});
 
 	it('throws a 503 when the API responds with an error', async () => {
-		const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
-		const event = makeEvent(mockFetch);
+		vi.mocked(fetchRecordsTracker).mockRejectedValue(new Error('Open-Meteo error: 502'));
+		const event = makeEvent();
 
 		await expect(load(event)).rejects.toMatchObject({ status: 503 });
 	});


### PR DESCRIPTION
## Summary

- **`records/+page.server.ts`** now calls `fetchRecordsTracker()` and the in-memory cache (`getCache`/`setCache`) directly, removing an unnecessary self-HTTP round-trip to `/api/records`. The cache key format is identical to the one used in the API route handler, so page loads and direct API requests share the same warm cache entry — whichever fires first populates it for both.
- **`package.json`** moves `accented` from `dependencies` to `devDependencies`. It is only imported inside an `import.meta.env.MODE === 'development'` guard in `+layout.svelte`, so Vite's dead-code elimination already excludes it from production bundles. Moving it to `devDependencies` reflects the true intent and avoids it being installed in production environments.

## What changed and why

### `records/+page.server.ts`
Before: the SvelteKit server `load` function called `fetch('/api/records')`, which SvelteKit routes internally to the `GET` handler in `src/routes/api/records/+server.ts`. Even though no external network hop occurs, this still serialises the result to JSON and deserialises it again, and duplicates the error-handling flow across two separate handlers.

After: the load function imports `fetchRecordsTracker` and the cache helpers directly. Error TTL caching (`-error` key) is preserved with the same 5-minute window. The `/api/records` endpoint is left intact for any other callers (e.g. direct API access, the widget components).

### `package.json`
`accented` was listed under `dependencies` but is explicitly excluded from production by `knip.json` (`"ignoreDependencies": ["accented"]`), confirming the intent was already known. This PR makes the placement match the intent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTDVKC7suZGbntTmuY72fS)_