### PR TITLE
chore(seo): fix records page OG images, dateModified, semantic HTML, and layout fallback meta

### DIFF
--- a/src/lib/graphql/queries/getPostBySlug.ts
+++ b/src/lib/graphql/queries/getPostBySlug.ts
@@ -6,6 +6,7 @@ const GET_POST_BY_SLUG = `
       slug
       excerpt
       date
+      modified
       content
       featuredImage {
         node {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,7 @@ export type GqlPostNode = {
 	slug: string;
 	excerpt?: string;
 	date: string;
+	modified?: string;
 	content: string;
 	featuredImage?: {
 		node?: GqlPostFeaturedImageNode;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,6 +41,8 @@
 </script>
 
 <svelte:head>
+	<title>Reading Weather — Forecasts &amp; Observations for Reading, UK</title>
+	<meta name="description" content="Weather forecasts, observations, and records for Reading, Berkshire, UK. Updated regularly with local conditions and seasonal outlooks." />
 	<link rel="preconnect" href="https://blog.readingweather.co.uk" crossorigin="anonymous" />
 	<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin="anonymous" />
 	<link rel="preload" href="/fonts/Caveat-VariableFont_wght.ttf" as="font" type="font/ttf" crossorigin="anonymous" />

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -58,7 +58,12 @@
 		url: postUrl,
 		inLanguage: 'en-GB',
 		mainEntityOfPage: { '@type': 'WebPage', '@id': postUrl },
-		...(data.post.date ? { datePublished: data.post.date, dateModified: data.post.date } : {}),
+		...(data.post.date
+			? {
+					datePublished: data.post.date,
+					dateModified: data.post.modified ?? data.post.date
+				}
+			: {}),
 		image: ogImageUrl,
 		author: {
 			'@type': 'Organization',

--- a/src/routes/records/+page.svelte
+++ b/src/routes/records/+page.svelte
@@ -14,12 +14,16 @@
 			: `Tracking Reading's weather records for ${records.year}`
 	);
 
+	const ogImage = 'https://www.readingweather.co.uk/images/weather.png';
+	const ogImageAlt = 'Weather illustration for Reading and Berkshire';
+
 	const jsonLd = $derived({
 		'@context': 'https://schema.org',
 		'@type': 'Dataset',
 		name: postTitle,
 		description: postSummary,
 		url: postUrl,
+		image: ogImage,
 		temporalCoverage: String(records.year),
 		spatialCoverage: {
 			'@type': 'Place',
@@ -58,8 +62,12 @@
 	<meta property="og:description" content={postSummary} />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={postUrl} />
+	<meta property="og:image" content={ogImage} />
+	<meta property="og:image:alt" content={ogImageAlt} />
 	<meta name="twitter:title" content={postTitle} />
 	<meta name="twitter:description" content={postSummary} />
+	<meta name="twitter:image" content={ogImage} />
+	<meta name="twitter:image:alt" content={ogImageAlt} />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}
 </svelte:head>
 
@@ -68,7 +76,7 @@
 <section class="records-tracker">
 	<p class="range">As of {records.asOf} · {records.yearsOfData} years of ERA5 records since 1940</p>
 
-	<div class="stat-group">
+	<section class="stat-group">
 		<h2>Records broken this year</h2>
 		{#if records.brokenRecords.length === 0}
 			<p>No all-time records have been broken in Reading yet in {records.year}.</p>
@@ -92,10 +100,10 @@
 				{/each}
 			</ul>
 		{/if}
-	</div>
+	</section>
 
 	{#if records.nearMisses.length > 0}
-		<div class="stat-group">
+		<section class="stat-group">
 			<h2>Near misses</h2>
 			<p class="range">Days that entered the all-time top 10 without quite breaking the record.</p>
 			<ul class="records">
@@ -116,10 +124,10 @@
 					</li>
 				{/each}
 			</ul>
-		</div>
-	{/if}
+		</section>
+{/if}
 
-	<div class="stat-group">
+	<section class="stat-group">
 		<h2>All-time records for Reading</h2>
 		<ul class="records">
 			{#each records.allTimeRecords as record (record.metric)}
@@ -135,7 +143,7 @@
 				</li>
 			{/each}
 		</ul>
-	</div>
+	</section>
 
 	<p class="conditions-note">
 		Weather records are sourced from ERA5 reanalysis data and should be treated as an approximate


### PR DESCRIPTION
## Summary

Accessibility and SEO improvements identified during an automated audit on 2026-08-23 (Sunday → randomly selected Accessibility & SEO category).

### Changes

**`src/routes/records/+page.svelte`**
- Added missing `og:image`, `og:image:alt`, `twitter:image`, `twitter:image:alt` meta tags. The records page was the only route in the whole site that omitted these, meaning any share to social media would render with no preview image or card.
- Added `image` property to the Dataset JSON-LD schema block to bring it in line with how other page types declare their image.
- Replaced the three `<div class="stat-group">` wrappers with `<section class="stat-group">` so that each `<h2>` heading lives inside a proper HTML sectioning element, which screen readers use to expose document outline and region navigation.

**`src/lib/graphql/queries/getPostBySlug.ts`**
- Added `modified` to the GraphQL query so the WordPress last-modified date is fetched alongside the publication date.

**`src/lib/types.ts`**
- Added `modified?: string` to `GqlPostNode` to reflect the newly-fetched field.

**`src/routes/[slug]/+page.svelte`**
- Updated the `BlogPosting` JSON-LD to use `data.post.modified ?? data.post.date` for `dateModified`, so that Google and other crawlers can distinguish when a forecast was last updated from when it was first published. This improves freshness signals, which matters for a weather site.

**`src/routes/+layout.svelte`**
- Added a fallback `<title>` and `<meta name="description">` to the layout `<svelte:head>`. Svelte merges head declarations from parent and child, so each page's own `<svelte:head>` overrides these. The fallback only activates for any future route that omits its own metadata, preventing a blank browser tab title or empty description crawl.

### What success looks like

- The records page renders a preview card with an image when shared on Twitter/X, Facebook, or LinkedIn.
- Google Search Console shows non-identical `datePublished` / `dateModified` for forecast posts that have been edited since first publication.
- Screen-reader users navigating by regions/landmarks on the records page see three named sections rather than anonymous div containers.
- Any accidentally-incomplete future route has a meaningful fallback title and description rather than an empty `<title>` tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01558D2ez4duo3KW6qnatSfW)_