### PR TITLE
Add share buttons to homepage stat cards

### DIFF
--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -3,14 +3,22 @@
 		postUrl: string;
 		postTitle: string;
 		postSummary: string;
+		card?: string;
 	};
 
-	const { postUrl, postTitle, postSummary }: Props = $props();
+	const { postUrl, postTitle, postSummary, card }: Props = $props();
 
 	let copied = $state(false);
 	let copyError = $state(false);
 
+	function trackShare(): void {
+		if (card && typeof window.gtag === 'function') {
+			window.gtag('event', 'share_click', { card });
+		}
+	}
+
 	function copyLink(): void {
+		trackShare();
 		navigator.clipboard
 			.writeText(postUrl)
 			.then(() => {
@@ -28,21 +36,25 @@
 	}
 
 	function shareOnBluesky(): void {
+		trackShare();
 		const url = `https://bsky.app/intent/compose?text=${encodeURIComponent(`${postSummary} ${postUrl}`)}`;
 		window.open(url, '_blank', 'noopener,noreferrer');
 	}
 
 	function shareOnThreads(): void {
+		trackShare();
 		const url = `https://www.threads.net/intent/post?text=${encodeURIComponent(`${postSummary} ${postUrl}`)}`;
 		window.open(url, '_blank', 'noopener,noreferrer');
 	}
 
 	function shareOnFacebook(): void {
+		trackShare();
 		const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(postUrl)}`;
 		window.open(url, '_blank', 'noopener,noreferrer');
 	}
 
 	function shareOnWhatsApp(): void {
+		trackShare();
 		const url = `https://api.whatsapp.com/send?text=${encodeURIComponent(`${postSummary} ${postUrl}`)}`;
 		window.open(url, '_blank', 'noopener,noreferrer');
 	}

--- a/src/lib/components/WeatherStreak.svelte
+++ b/src/lib/components/WeatherStreak.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { STREAK_KEY, type WeatherStreakResult } from '$lib/api/weatherStreak';
+	import ShareButton from '$lib/components/ShareButton.svelte';
 
 	let streak = $state<WeatherStreakResult | null>(null);
 
@@ -48,5 +49,11 @@
 			Streak measured through {streak.asOf}. Weather conditions are sourced from ERA5
 			reanalysis data and should be treated as an approximate guide only.
 		</p>
+		<ShareButton
+			postUrl="https://www.readingweather.co.uk/"
+			postTitle="Reading Weather Streak Tracker"
+			postSummary="{streak.active.headline} — {streak.active.context}"
+			card="streak"
+		/>
 	</section>
 {/if}

--- a/src/lib/components/WeekInHistory.svelte
+++ b/src/lib/components/WeekInHistory.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { WeekInHistory } from '$lib/api/weekInHistory';
+	import ShareButton from '$lib/components/ShareButton.svelte';
 
 	let history = $state<WeekInHistory | null>(null);
 
@@ -34,5 +35,12 @@
 			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
 			approximate guide only
 		</p>
+		<ShareButton
+			postUrl="https://www.readingweather.co.uk/"
+			postTitle="This Week in Reading Weather History"
+			postSummary="Wettest week on record in Reading: {history.wettestWeek.value}mm in {history
+				.wettestWeek.year}"
+			card="week_in_history"
+		/>
 	</section>
 {/if}

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { WeeklyDigest } from '$lib/api/weeklyDigest';
+	import ShareButton from '$lib/components/ShareButton.svelte';
 
 	let digest = $state<WeeklyDigest | null>(null);
 
@@ -54,5 +55,11 @@
 			Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
 			approximate guide only
 		</p>
+		<ShareButton
+			postUrl="https://www.readingweather.co.uk/"
+			postTitle="Last Week in Reading"
+			postSummary="Last week in Reading: {digest.tempHigh}°C high, {digest.totalPrecipitation}mm rain — {capitalize(digest.dominantConditions)}"
+			card="digest"
+		/>
 	</section>
 {/if}


### PR DESCRIPTION
## Summary
- Reuse the existing `ShareButton` component on `WeatherStreak`, `WeeklyDigest`, and `WeekInHistory` so readers can share these homepage highlights (streak, weekly digest, week-in-history records) directly to Bluesky, Threads, Facebook, or WhatsApp, or copy a link
- Add an optional `card` prop to `ShareButton` that fires `gtag('event', 'share_click', { card })` per card for tracking, as suggested in the issue's success metric

Closes #450

## Test plan
- [x] `svelte-check` passes with no errors
- [x] Unit test suite passes (208/208)
- [ ] Manual check in browser that each homepage card renders its share button and links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8aQzHqPV65JwuQ9n8ekTE