### PR TITLE
chore(a11y+seo): improve accessible landmarks and add missing SEO meta tags

### DIFF
--- a/src/lib/components/WeatherStreak.svelte
+++ b/src/lib/components/WeatherStreak.svelte
@@ -16,8 +16,8 @@
 </script>
 
 {#if streak}
-	<section class="weather-streak">
-		<h2>Reading Weather Streak Tracker</h2>
+	<section class="weather-streak" aria-labelledby="streak-heading">
+		<h2 id="streak-heading">Reading Weather Streak Tracker</h2>
 		<p class="headline">
 			<span aria-hidden="true">{streak.active.emoji}</span>
 			<strong>{streak.active.headline}</strong>

--- a/src/lib/components/WeekInHistory.svelte
+++ b/src/lib/components/WeekInHistory.svelte
@@ -16,8 +16,8 @@
 </script>
 
 {#if history}
-	<section class="week-in-history">
-		<h2>This Week in Reading Weather History</h2>
+	<section class="week-in-history" aria-labelledby="week-history-heading">
+		<h2 id="week-history-heading">This Week in Reading Weather History</h2>
 		<p class="range">{history.windowLabel} · {history.yearsOfData} years of records</p>
 		<ul class="records">
 			<li>

--- a/src/lib/components/WeeklyDigest.svelte
+++ b/src/lib/components/WeeklyDigest.svelte
@@ -32,8 +32,8 @@
 </script>
 
 {#if digest}
-	<section class="weekly-digest">
-		<h2>Last Week in Reading</h2>
+	<section class="weekly-digest" aria-labelledby="weekly-digest-heading">
+		<h2 id="weekly-digest-heading">Last Week in Reading</h2>
 		<p class="range">{formatRange(digest.startDate, digest.endDate)}</p>
 		<div class="stats">
 			<span><span aria-hidden="true">↑</span><span class="sr-only">High: </span>{digest.tempHigh}°C</span>

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -119,6 +119,9 @@
 	{#if data.post.date}
 		<meta property="article:published_time" content={data.post.date} />
 	{/if}
+	{#if data.post.modified}
+		<meta property="article:modified_time" content={data.post.modified} />
+	{/if}
 	<meta property="article:author" content="Reading Weather" />
 	<meta name="twitter:title" content={postTitle} />
 	<meta name="twitter:description" content={postDescription} />

--- a/src/routes/archives/+page.svelte
+++ b/src/routes/archives/+page.svelte
@@ -40,16 +40,23 @@
 </script>
 
 <svelte:head>
-	<title>Weather Forecast Archives – Reading Weather</title>
-	<meta name="description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
-	<meta property="og:title" content="Weather Forecast Archives – Reading Weather" />
-	<meta property="og:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
+	{#if data.selectedYear && data.selectedMonth}
+		<title>{getMonthName(data.selectedMonth)} {data.selectedYear} Forecasts – Reading Weather</title>
+		<meta name="description" content="Weather forecasts for Reading and Berkshire from {getMonthName(data.selectedMonth)} {data.selectedYear}." />
+		<meta property="og:title" content="{getMonthName(data.selectedMonth)} {data.selectedYear} Forecasts – Reading Weather" />
+		<meta property="og:description" content="Weather forecasts for Reading and Berkshire from {getMonthName(data.selectedMonth)} {data.selectedYear}." />
+	{:else}
+		<title>Weather Forecast Archives – Reading Weather</title>
+		<meta name="description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
+		<meta property="og:title" content="Weather Forecast Archives – Reading Weather" />
+		<meta property="og:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
+	{/if}
 	<meta property="og:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta property="og:image:alt" content="Reading Weather – weather forecasts for Reading and Berkshire" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://www.readingweather.co.uk/archives" />
-	<meta name="twitter:title" content="Weather Forecast Archives – Reading Weather" />
-	<meta name="twitter:description" content="Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year." />
+	<meta name="twitter:title" content={data.selectedYear && data.selectedMonth ? `${getMonthName(data.selectedMonth)} ${data.selectedYear} Forecasts – Reading Weather` : 'Weather Forecast Archives – Reading Weather'} />
+	<meta name="twitter:description" content={data.selectedYear && data.selectedMonth ? `Weather forecasts for Reading and Berkshire from ${getMonthName(data.selectedMonth)} ${data.selectedYear}.` : 'Browse the archives of weather forecasts for Reading and Berkshire, searchable by month and year.'} />
 	<meta name="twitter:image" content="https://www.readingweather.co.uk/images/weather.png" />
 	<meta name="twitter:image:alt" content="Reading Weather – weather forecasts for Reading and Berkshire" />
 	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`}

--- a/src/routes/monthly-summary/+page.svelte
+++ b/src/routes/monthly-summary/+page.svelte
@@ -56,12 +56,14 @@
 
 <h1>Monthly Weather Report Cards</h1>
 
-<ul class="monthly-summary-index">
-	{#each data.months as { year, month } (`${year}-${month}`)}
-		<li>
-			<a href="/monthly-summary/{year}/{String(month).padStart(2, '0')}">
-				{MONTH_NAMES[month - 1]} {year}
-			</a>
-		</li>
-	{/each}
-</ul>
+<nav aria-label="Monthly report cards">
+	<ul class="monthly-summary-index">
+		{#each data.months as { year, month } (`${year}-${month}`)}
+			<li>
+				<a href="/monthly-summary/{year}/{String(month).padStart(2, '0')}">
+					{MONTH_NAMES[month - 1]} {year}
+				</a>
+			</li>
+		{/each}
+	</ul>
+</nav>

--- a/src/routes/monthly-summary/[year]/[month]/+page.svelte
+++ b/src/routes/monthly-summary/[year]/[month]/+page.svelte
@@ -62,7 +62,7 @@
 
 <h1>{summary.label} Weather Report Card</h1>
 
-<section class="monthly-summary-card">
+<div class="monthly-summary-card">
 	<p class="headline">{summary.headline}</p>
 
 	<section class="stat-group">
@@ -152,7 +152,7 @@
 		Weather conditions are sourced from ERA5 reanalysis data and should be treated as an
 		approximate guide only
 	</p>
-</section>
+</div>
 
 <ShareButton {postUrl} {postTitle} postSummary={summary.headline} />
 

--- a/src/routes/records/+page.svelte
+++ b/src/routes/records/+page.svelte
@@ -73,7 +73,7 @@
 
 <h1>{postTitle}</h1>
 
-<section class="records-tracker">
+<div class="records-tracker">
 	<p class="range">As of {records.asOf} · {records.yearsOfData} years of ERA5 records since 1940</p>
 
 	<section class="stat-group">
@@ -149,6 +149,6 @@
 		Weather records are sourced from ERA5 reanalysis data and should be treated as an approximate
 		guide only
 	</p>
-</section>
+</div>
 
 <ShareButton {postUrl} {postTitle} {postSummary} />


### PR DESCRIPTION
## Summary

This PR addresses accessibility and SEO issues found during a review of the SvelteKit codebase.

### Accessibility improvements

- **Section landmark labelling** — `WeatherStreak`, `WeekInHistory`, and `WeeklyDigest` components each rendered a `<section>` with an `<h2>` heading but no `aria-labelledby` association. Added `id` attributes to the headings and matching `aria-labelledby` on the sections so assistive technologies can identify each region.
- **Navigation landmark for monthly summary index** — The list of monthly report cards on `/monthly-summary` was a bare `<ul>`. Wrapped it in `<nav aria-label="Monthly report cards">` so screen-reader users can navigate to it directly via landmarks.
- **Unlabelled container sections replaced with `<div>`** — `<section class="records-tracker">` (records page) and `<section class="monthly-summary-card">` (monthly summary detail page) had no heading and so did not constitute meaningful landmarks. Changed both to `<div>` to avoid polluting the accessibility tree with phantom regions; the inner `<section class="stat-group">` elements each retain their own `<h2>` labels.

### SEO improvements

- **`article:modified_time` Open Graph meta tag** — The individual post page (`[slug]/+page.svelte`) already exposes `dateModified` in its JSON-LD but was missing the Open Graph `article:modified_time` meta tag. Added it using the existing `data.post.modified` field so social crawlers and search engines can track content freshness.
- **Dynamic `<title>` and meta on the archives page** — `/archives?year=2024&month=01` previously always rendered the generic title "Weather Forecast Archives – Reading Weather" even when a specific month was selected via URL params. The title, `og:title`, `og:description`, and twitter meta tags are now dynamic: when year and month params are present the title becomes e.g. "January 2024 Forecasts – Reading Weather", giving crawlable archive URLs unique, descriptive page titles.

### Testing

- `yarn lint` passes cleanly (Biome: no errors, 125 files checked).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhLro1GFZwt85vfzGWBAXn)_