### PR TITLE
chore(types): remove unsafe `as Response` cast in recordsTracker fetchArchive

### DIFF
--- a/src/lib/api/recordsTracker.ts
+++ b/src/lib/api/recordsTracker.ts
@@ -147,16 +147,18 @@ function round1(n: number): number {
 }
 
 async function fetchArchive(url: string): Promise<Response> {
-	let response: Response | undefined;
 	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-		response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+		const response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
 		if (response.status !== 429 || attempt === MAX_ATTEMPTS) return response;
 
 		const retryAfterSeconds = Number(response.headers.get('retry-after'));
 		const delayMs = retryAfterSeconds > 0 ? retryAfterSeconds * 1000 : attempt * 1000;
 		await new Promise((resolve) => setTimeout(resolve, delayMs));
 	}
-	return response as Response;
+	// Unreachable: the loop always returns on the final attempt. TypeScript cannot
+	// prove this because MAX_ATTEMPTS is a runtime constant, not a literal in the
+	// loop bounds, so an explicit throw satisfies the control-flow analysis.
+	throw new Error('Unexpected: fetchArchive retry loop exhausted without returning');
 }
 
 export async function fetchRecordsTracker(now: Date = new Date()): Promise<RecordsTrackerResult> {


### PR DESCRIPTION
## Summary

- Removes the `as Response` type assertion from `fetchArchive` in `src/lib/api/recordsTracker.ts`
- Replaces the `let response: Response | undefined` + end-of-loop cast pattern with `const response` inside the loop and an explicit `throw` after it — the same approach already used in the identical `fetchArchive` function in `monthlySummary.ts`

## Detail

The retry loop always returns on the final attempt, but TypeScript cannot prove this when `MAX_ATTEMPTS` is a runtime constant rather than a literal in the loop bounds. The old workaround declared `response` as `Response | undefined` and cast it to `Response` at the end, which hides a genuine gap: if the loop were ever skipped (e.g. `MAX_ATTEMPTS` set to 0), the cast would silently produce `undefined as Response` rather than erroring.

The fix aligns with `monthlySummary.ts` by:
1. Moving the `const response` declaration inside the loop, so each iteration's type is cleanly narrowed without a mutable outer binding.
2. Adding an explicit `throw new Error(...)` after the loop to satisfy control-flow analysis without any type assertion.

`svelte-check` (0 errors, 0 warnings) and `biome check` (no fixes applied) both pass after the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KF3LHXNiAi19d5AqMkgY5A)_