### PR TITLE
Fix homepage weather streak claiming "longest so far this year" incorrectly

### DIFF
--- a/src/lib/api/weatherStreak.spec.ts
+++ b/src/lib/api/weatherStreak.spec.ts
@@ -211,6 +211,28 @@ describe('fetchWeatherStreak', () => {
 		expect(result?.active.context).toBe('the longest so far this year');
 	});
 
+	it('does not call the active streak "the longest so far this year" when an earlier, longer streak already happened this year', async () => {
+		const time = dateRange('2016-07-10', '2026-07-09');
+		const precipitation_sum = Array(time.length).fill(5);
+		// An 8-day dry spell in March 2026 is longer than the current 3-day streak
+		// ending "yesterday" — both fall within the same year as NOW.
+		const idxMarchStart = time.indexOf('2026-03-01');
+		for (let i = idxMarchStart; i < idxMarchStart + 8; i++) precipitation_sum[i] = 0;
+		for (let i = time.length - 3; i < time.length; i++) precipitation_sum[i] = 0;
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(makeArchiveResponse(time, { precipitation_sum }))
+		);
+
+		const result = await fetchWeatherStreak(NOW);
+		expect(result?.active.type).toBe('dry');
+		expect(result?.active.length).toBe(3);
+		expect(result?.active.context).toBe(
+			'not the longest this year — March had a longer run (8 days)'
+		);
+	});
+
 	it('describes the dry threshold as under 0.5mm, not zero, so drizzle still counts', () => {
 		const dry = STREAK_KEY.find((k) => k.type === 'dry');
 		expect(dry?.description).toBe(

--- a/src/lib/api/weatherStreak.ts
+++ b/src/lib/api/weatherStreak.ts
@@ -151,6 +151,24 @@ function findRuns(matches: boolean[]): Run[] {
 }
 
 function buildContext(currentLength: number, priorRuns: Run[], dates: string[], currentYear: number): string {
+	const yearOf = (r: Run) => new Date(dates[r.endIndex]).getUTCFullYear();
+
+	// A strictly longer run earlier this year means the active streak isn't a
+	// record at all — calling it "the longest so far this year" would be false,
+	// unlike a tie, which still fairly counts as (tied-)longest so far.
+	const longerThisYear = priorRuns
+		.filter((r) => yearOf(r) === currentYear && r.length > currentLength)
+		.sort((a, b) => b.length - a.length || b.endIndex - a.endIndex);
+
+	if (longerThisYear.length > 0) {
+		const best = longerThisYear[0];
+		const monthName = new Date(dates[best.endIndex]).toLocaleString('en-GB', {
+			month: 'long',
+			timeZone: 'UTC'
+		});
+		return `not the longest this year — ${monthName} had a longer run (${best.length} days)`;
+	}
+
 	const atLeastAsLong = priorRuns
 		.filter((r) => r.length >= currentLength)
 		.sort((a, b) => b.endIndex - a.endIndex);
@@ -159,7 +177,7 @@ function buildContext(currentLength: number, priorRuns: Run[], dates: string[], 
 		return `the longest in at least ${HISTORY_YEARS} years of records`;
 	}
 
-	const year = new Date(dates[atLeastAsLong[0].endIndex]).getUTCFullYear();
+	const year = yearOf(atLeastAsLong[0]);
 	// A match found earlier in the same year isn't a meaningful "since <year>" —
 	// that phrasing only makes sense pointing back at a previous year.
 	return year === currentYear ? 'the longest so far this year' : `the longest since ${year}`;


### PR DESCRIPTION
## Summary
- The homepage weather streak tracker was labeling the active streak "the longest so far this year" even when a **strictly longer** streak of the same type had already occurred earlier in the same year — e.g. "🌞 5 sunny days in a row ... the longest so far this year" when an 8-day sunny streak had happened in March.
- Root cause: `buildContext` in `src/lib/api/weatherStreak.ts` only checked whether the most recent prior streak with length **≥** the current one fell in the current year, without distinguishing a tie (fair to still call "longest so far") from a strictly longer run (which makes the claim false).
- Fix: when a strictly longer streak already happened this year, the context now reads `"not the longest this year — <Month> had a longer run (<n> days)"` instead. Ties still correctly report `"the longest so far this year"`.

## Test plan
- [x] Added a regression test reproducing the reported bug (3-day active streak vs. an earlier 8-day streak in March, same year)
- [x] `npx vitest run` — all 209 tests pass
- [x] `npm run check` — 0 errors/warnings
- [x] `npm run lint` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_016vyeAbt4N3Kmbc7j5bJy2e)_